### PR TITLE
Fix #53 - warnings in example code

### DIFF
--- a/example/client.py
+++ b/example/client.py
@@ -11,6 +11,6 @@ def hello():
     print("> {}".format(name))
     greeting = yield from websocket.recv()
     print("< {}".format(greeting))
-    yield from websocket.close()
+    yield from websocket.worker
 
 asyncio.get_event_loop().run_until_complete(hello())

--- a/example/client.py
+++ b/example/client.py
@@ -11,5 +11,6 @@ def hello():
     print("> {}".format(name))
     greeting = yield from websocket.recv()
     print("< {}".format(greeting))
+    yield from websocket.close()
 
 asyncio.get_event_loop().run_until_complete(hello())


### PR DESCRIPTION
It is quite unclear why client cannot use

```
yield from websocket.close()
```

as it is said in the documentation (“Clients shouldn’t close the WebSocket connection. Instead, they should wait until the server performs the closing handshake by yielding from the protocol’s worker attribute.”)

As such, it is replaced with

```
yield from websocket.worker
```

It works and no warnings are shown, but in this form the code is poorly readable and unclear what does this code do.