### PR TITLE
Add flow control for websocket reader

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 *In development*
 
 * Avoided a warning when closing a connection before the opening handshake.
+* Add flow control when reading from a websocket. (The previous flow control
+  implementation only affected *writes* to a websocket.)
 
 3.0
 ...

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -62,6 +62,13 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
     raise :exc:`~websockets.exceptions.ConnectionClosed` and the connection
     will be closed with status code 1009.
 
+    The ``max_queue`` parameter sets the maximum size for the incoming message
+    queue. The default value is 1024. ``0`` (zero) disables the limit. When the
+    queue is full, no more messages will be read from the websocket. In this
+    full condition, the system's receive buffer will being to fill and the TCP
+    receive window will shrink. A well-behaved peer will slow down transmission
+    in order to avoid packet loss.
+
     Once the handshake is complete, request and response HTTP headers are
     available:
 


### PR DESCRIPTION
The patch for flow control is 3 lines. I updated the documentation in a separate commit, in case you want to cherry pick the patch by itself. I tried really hard to think of a way to write an automated test for this, but couldn't come up with anything that works. (You weren't kidding when you said that unit testing `asyncio` code is hard.)