### PR TITLE
MANIFEST: add README.rst as needed in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
+include README.rst
 
 graft websockets/py35


### PR DESCRIPTION
I think README.rst is not present in the tarball. Then setup.py fails :/