### PR TITLE
Fix tests on Python 3.5.2

### DIFF
--- a/websockets/test_protocol.py
+++ b/websockets/test_protocol.py
@@ -258,7 +258,10 @@ class CommonTests:
         self.run_loop_once()
         # The connection is established.
         self.assertEqual(self.protocol.local_address, ('host', 4312))
-        get_extra_info.assert_called_once_with('sockname', None)
+        if get_extra_info.call_count == 2:
+            assert get_extra_info.call_args_list == [(('sslcontext',),), (('sockname', None),)]
+        else:
+            get_extra_info.assert_called_once_with('sockname', None)
 
     def test_remote_address(self):
         get_extra_info = unittest.mock.Mock(return_value=('host', 4312))
@@ -268,7 +271,10 @@ class CommonTests:
         self.run_loop_once()
         # The connection is established.
         self.assertEqual(self.protocol.remote_address, ('host', 4312))
-        get_extra_info.assert_called_once_with('peername', None)
+        if get_extra_info.call_count == 2:
+            assert get_extra_info.call_args_list == [(('sslcontext',),), (('peername', None),)]
+        else:
+            get_extra_info.assert_called_once_with('peername', None)
 
     def test_open(self):
         self.assertTrue(self.protocol.open)


### PR DESCRIPTION
get_extra_info is called with 'sslcontext' before being called as
expected. Adapt the tests accordingly.

Close #123 

PS: I looked at the [changelog](https://docs.python.org/3/whatsnew/changelog.html) for 3.5.2 but found nothing that could explain this. There are some changes about SSL but they only concerns Windows.
