### PR TITLE
Update intro.rst with a better producer/consumer

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -111,7 +111,7 @@ messages on the same connection.
                 producer_task = asyncio.ensure_future(producer())
                 pending.add(producer_task)
 
-(This code looks convoluted. If you know a more straightforward solution, 
+(This code looks convoluted. If you know a more straightforward solution,
 please let me know about it!)
 
 Registration

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -111,6 +111,8 @@ messages on the same connection.
                 producer_task = asyncio.ensure_future(producer())
                 pending.add(producer_task)
 
+(This code looks convoluted. If you know a more straightforward solution, 
+please let me know about it!)
 
 Registration
 ............


### PR DESCRIPTION
See gist for example test cases https://gist.github.com/wojtossfm/aede13446bb3b9e12942109f505058c1

The example code for the docs is prone to a race condition of the state of the tasks. If people replicate it they might wonder why they are losing messages (due to the cancel calls). The proposed change avoids the race condition. I tried to change as little as possible in the example.

If I'm missing something or something is unclear then let me know.

Just thought I'd chip in if I can. Great library by the way.
