### PR TITLE
Compressor output should always end with 0x0000FFFF

### DIFF
--- a/websockets/extensions.py
+++ b/websockets/extensions.py
@@ -96,7 +96,5 @@ class PerMessageDeflate:
             self.encoder.compress(frame.data) +
             self.encoder.flush(zlib.Z_SYNC_FLUSH)
         )
-        if data.endswith(_EMPTY_UNCOMPRESSED_BLOCK):
-            data = data[:-4]
-
-        return frame._replace(data=data, rsv1=frame.opcode != OP_CONT)
+        assert data.endswith(_EMPTY_UNCOMPRESSED_BLOCK)
+        return frame._replace(data=data[:-4], rsv1=frame.opcode != OP_CONT)


### PR DESCRIPTION
According to RFC7692, section 7.2.1
```
 3.  Remove 4 octets (that are 0x00 0x00 0xff 0xff) from the tail end.
       After this step, the last octet of the compressed data contains
       (possibly part of) the DEFLATE header bits with the "BTYPE" bits
       set to 00.
```