### PR TITLE
Support `permessage-deflate` parameters

### DIFF
--- a/compliance/fuzzingclient.json
+++ b/compliance/fuzzingclient.json
@@ -6,6 +6,6 @@
    "servers": [{"agent": "websockets", "url": "ws://localhost:8642", "options": {"version": 18}}],
 
    "cases": ["*"],
-   "exclude-cases": [],
+   "exclude-cases": ["12.*", "13.*"],
    "exclude-agent-cases": {}
 }

--- a/compliance/fuzzingclient.json
+++ b/compliance/fuzzingclient.json
@@ -6,6 +6,6 @@
    "servers": [{"agent": "websockets", "url": "ws://localhost:8642", "options": {"version": 18}}],
 
    "cases": ["*"],
-   "exclude-cases": ["12.*", "13.*"],
+   "exclude-cases": ["12.5.*"],
    "exclude-agent-cases": {}
 }

--- a/compliance/fuzzingserver.json
+++ b/compliance/fuzzingserver.json
@@ -7,6 +7,6 @@
    "webport": 8080,
 
    "cases": ["*"],
-   "exclude-cases": [],
+   "exclude-cases": ["12.*", "13.*"],
    "exclude-agent-cases": {}
 }

--- a/compliance/fuzzingserver.json
+++ b/compliance/fuzzingserver.json
@@ -3,10 +3,10 @@
    "url": "ws://localhost:8642",
 
    "options": {"failByDrop": false},
-   "outdir": "./reports/clients",
+   "outdir": "./reports/servers",
    "webport": 8080,
 
    "cases": ["*"],
-   "exclude-cases": ["12.*", "13.*"],
+   "exclude-cases": ["12.5.*"],
    "exclude-agent-cases": {}
 }

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -7,9 +7,8 @@ import asyncio
 import collections.abc
 import email.message
 
-from websockets.extensions import parse_extensions, PerMessageDeflate
-
 from .exceptions import InvalidHandshake, InvalidMessage
+from .extensions import PerMessageDeflate, parse_extensions
 from .handshake import build_request, check_response
 from .http import USER_AGENT, read_response
 from .protocol import CONNECTING, OPEN, WebSocketCommonProtocol
@@ -37,7 +36,9 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         self.available_extensions = []
         if use_compression:
             self.available_extensions.append(
-                'permessage-deflate; client_no_context_takeover; client_max_window_bits'
+                'permessage-deflate; '
+                'client_no_context_takeover; '
+                'client_max_window_bits'
             )
         if extensions:
             self.available_extensions.append(extensions)

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -32,11 +32,13 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
 
     def __init__(self, *,
                  origin=None, extensions=None, subprotocols=None,
-                 extra_headers=None, **kwds):
+                 extra_headers=None, use_compression=True, **kwds):
         self.origin = origin
-        self.available_extensions = [
-            'permessage-deflate; client_no_context_takeover; client_max_window_bits'
-        ]
+        self.available_extensions = []
+        if use_compression:
+            self.available_extensions.append(
+                'permessage-deflate; client_no_context_takeover; client_max_window_bits'
+            )
         if extensions:
             self.available_extensions.append(extensions)
         self.available_subprotocols = subprotocols
@@ -182,7 +184,7 @@ def connect(uri, *,
             read_limit=2 ** 16, write_limit=2 ** 16,
             loop=None, legacy_recv=False,
             origin=None, extensions=None, subprotocols=None,
-            extra_headers=None, **kwds):
+            extra_headers=None, use_compression=True, **kwds):
     """
     This coroutine connects to a WebSocket server at a given ``uri``.
 
@@ -211,6 +213,7 @@ def connect(uri, *,
       decreasing preference
     * ``extra_headers`` sets additional HTTP request headers – it can be a
       mapping or an iterable of (name, value) pairs
+    * ``use_compression`` allow client to force compression to be disabled
 
     :func:`connect` raises :exc:`~websockets.uri.InvalidURI` if ``uri`` is
     invalid and :exc:`~websockets.handshake.InvalidHandshake` if the opening
@@ -235,7 +238,7 @@ def connect(uri, *,
         read_limit=read_limit, write_limit=write_limit,
         loop=loop, legacy_recv=legacy_recv,
         origin=origin, extensions=extensions, subprotocols=subprotocols,
-        extra_headers=extra_headers,
+        extra_headers=extra_headers, use_compression=use_compression
     )
 
     transport, protocol = yield from loop.create_connection(

--- a/websockets/extensions.py
+++ b/websockets/extensions.py
@@ -181,7 +181,7 @@ class PerMessageDeflate:
             self.encoder.compress(frame.data) +
             self.encoder.flush(zlib.Z_SYNC_FLUSH)
         )
-        if data.endswith(_EMPTY_UNCOMPRESSED_BLOCK):
+        if data.endswith(_EMPTY_UNCOMPRESSED_BLOCK):  # pragma: no cover
             data = data[:-4]
 
         return frame._replace(data=data, rsv1=frame.opcode != OP_CONT)

--- a/websockets/extensions.py
+++ b/websockets/extensions.py
@@ -1,0 +1,102 @@
+import zlib
+
+from .framing import CTRL_OPCODES, OP_CONT
+
+
+__all__ = ['PerMessageDeflate']
+
+
+_EMPTY_UNCOMPRESSED_BLOCK = b'\x00\x00\xff\xff'
+
+
+class PerMessageDeflate:
+    """
+    Compression Extensions for WebSocket (`RFC 7692`_).
+
+    .. _RFC 7692: http://tools.ietf.org/html/rfc7692
+
+    """
+
+    # This class implements the server-side behavior by default.
+    # To get the client-side behavior, set is_client = True.
+    is_client = False
+
+    def __init__(self):
+        # Currently there's no way to customize these parameters.
+        self.server_no_context_takeover = False
+        self.client_no_context_takeover = False
+        self.server_max_window_bits = 15
+        self.client_max_window_bits = 15
+        # Internal state.
+        self.decoder = zlib.decompressobj(
+            wbits=-(
+                self.server_max_window_bits
+                if self.is_client else
+                self.client_max_window_bits
+            ),
+        )
+        self.encoder = zlib.compressobj(
+            wbits=-(
+                self.client_max_window_bits
+                if self.is_client else
+                self.server_max_window_bits
+            ),
+        )
+        self.decode_cont_data = False
+        self.encode_cont_data = False
+
+    def name(self):
+        return 'permessage-deflate'
+
+    def decode(self, frame):
+        """
+        Decode an incoming frame.
+
+        """
+        # Skip control frames.
+        if frame.opcode in CTRL_OPCODES:
+            return frame
+        # Handle continuation data frames:
+        # - skip if the initial data frame wasn't encoded
+        # - reset "decode continuation data" flag if it's a final frame
+        elif frame.opcode == OP_CONT:
+            if not self.decode_cont_data:
+                return frame
+            if frame.fin:
+                self.decode_cont_data = False
+        # Handle text and binary data frames:
+        # - skip if the frame isn't encoded
+        # - set "decode continuation data" flag if it's a non-final frame
+        else:
+            if not frame.rsv1:
+                return frame
+            if not frame.fin:   # frame.rsv1 is True at this point
+                self.decode_cont_data = True
+
+        # Uncompress compressed frames.
+        data = frame.data
+        if frame.fin:
+            data += _EMPTY_UNCOMPRESSED_BLOCK
+        data = self.decoder.decompress(data)
+
+        return frame._replace(data=data, rsv1=False)
+
+    def encode(self, frame):
+        """
+        Encode an outgoing frame.
+
+        """
+        # Skip control frames.
+        if frame.opcode in CTRL_OPCODES:
+            return frame
+
+        # Compress data frames.
+        # Since we don't do fragmentation, this is easy.
+        data = (
+            self.encoder.compress(frame.data) +
+            self.encoder.flush(zlib.Z_SYNC_FLUSH)
+        )
+        if data.endswith(_EMPTY_UNCOMPRESSED_BLOCK):
+            data = data[:-4]
+
+        return frame._replace(data=data, rsv1=frame.opcode != OP_CONT)

--- a/websockets/framing.py
+++ b/websockets/framing.py
@@ -71,7 +71,7 @@ class Frame(FrameData):
 
     @classmethod
     @asyncio.coroutine
-    def read(cls, reader, *, mask, max_size=None, extensions=()):
+    def read(cls, reader, *, mask, max_size=None, extensions=None):
         """
         Read a WebSocket frame and return a :class:`Frame` object.
 
@@ -127,14 +127,16 @@ class Frame(FrameData):
 
         frame = cls(fin, opcode, data, rsv1, rsv2, rsv3)
 
-        frame.check()
-
+        if extensions is None:
+            extensions = []
         for extension in reversed(extensions):
             frame = extension.decode(frame)
 
+        frame.check()
+
         return frame
 
-    def write(frame, writer, *, mask, extensions=()):
+    def write(frame, writer, *, mask, extensions=None):
         """
         Write a WebSocket frame.
 
@@ -155,13 +157,15 @@ class Frame(FrameData):
 
         """
 
+        frame.check()
+
         # The first parameter is called `frame` rather than `self`,
         # but it's the instance of class to which this method is bound.
 
+        if extensions is None:
+            extensions = []
         for extension in extensions:
             frame = extension.encode(frame)
-
-        frame.check()
 
         output = io.BytesIO()
 

--- a/websockets/framing.py
+++ b/websockets/framing.py
@@ -19,6 +19,7 @@ from .exceptions import PayloadTooBig, WebSocketProtocolError
 
 
 __all__ = [
+    'DATA_OPCODES', 'CTRL_OPCODES',
     'OP_CONT', 'OP_TEXT', 'OP_BINARY', 'OP_CLOSE', 'OP_PING', 'OP_PONG',
     'Frame', 'parse_close', 'serialize_close'
 ]
@@ -83,8 +84,9 @@ class Frame(FrameData):
         If ``max_size`` is set and the payload exceeds this size in bytes,
         :exc:`~websockets.exceptions.PayloadTooBig` is raised.
 
-        If ``extensions`` is provided, it's a list of functions that transform
-        the frame and return it. They are applied in reverse order.
+        If ``extensions`` is provided, it's a list of classes with an
+        ``decode()`` method that transform the frame and return a new frame.
+        They are applied in order.
 
         This function validates the frame before returning it and raises
         :exc:`~websockets.exceptions.WebSocketProtocolError` if it contains
@@ -128,7 +130,7 @@ class Frame(FrameData):
         frame.check()
 
         for extension in reversed(extensions):
-            frame = extension(frame)
+            frame = extension.decode(frame)
 
         return frame
 
@@ -143,8 +145,9 @@ class Frame(FrameData):
         ``mask`` is a :class:`bool` telling whether the frame should be masked
         i.e. whether the write happens on the client side.
 
-        If ``extensions`` is provided, it's a list of functions that transform
-        the frame and return it. They are applied in order.
+        If ``extensions`` is provided, it's a list of classes with an
+        ``encode()`` method that transform the frame and return a new frame.
+        They are applied in order.
 
         This function validates the frame before sending it and raises
         :exc:`~websockets.exceptions.WebSocketProtocolError` if it contains
@@ -156,7 +159,7 @@ class Frame(FrameData):
         # but it's the instance of class to which this method is bound.
 
         for extension in extensions:
-            frame = extension(frame)
+            frame = extension.encode(frame)
 
         frame.check()
 

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -148,6 +148,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         self.response_headers = None
         self.raw_response_headers = None
 
+        self.extensions = []
         self.subprotocol = None
 
         # Code and reason must be set when the closing handshake completes.
@@ -542,6 +543,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             self.reader.readexactly,
             mask=not self.is_client,
             max_size=max_size,
+            extensions=self.extensions,
         )
         logger.debug(
             "%s << %s",
@@ -569,6 +571,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         frame.write(
             self.writer.write,
             mask=self.is_client,
+            extensions=self.extensions,
         )
 
         # Backport of the combined logic of:

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -217,7 +217,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             for extension in extensions:
                 extension, params = extension.split(';', 1)
                 if extension == 'permessage-deflate':
-                    return [PerMessageDeflate()]
+                    return [PerMessageDeflate(params)]
         return []
 
     def process_subprotocol(self, get_header, available_subprotocols=None):
@@ -330,7 +330,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         # Status code is 101, establish the connection.
         if self.extensions:
             set_header('Sec-WebSocket-Extensions', ', '.join(
-                extension.name() for extension in self.extensions))
+                extension.response() for extension in self.extensions))
         if self.subprotocol:
             set_header('Sec-WebSocket-Protocol', self.subprotocol)
         if extra_headers is not None:

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -12,7 +12,7 @@ import logging
 
 from .compatibility import asyncio_ensure_future
 from .exceptions import InvalidHandshake, InvalidMessage, InvalidOrigin
-from .extensions import PerMessageDeflate
+from .extensions import PerMessageDeflate, parse_extensions
 from .handshake import build_response, check_request
 from .http import USER_AGENT, read_request
 from .protocol import CONNECTING, OPEN, WebSocketCommonProtocol
@@ -210,14 +210,11 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         # TODO this doesn't allow configuring available extensions.
         extensions = get_header('Sec-WebSocket-Extensions')
         if extensions:
-            extensions = [
-                extension.strip()
-                for extension in extensions.split(',')
-            ]
+            extensions = parse_extensions(extensions)
             for extension in extensions:
-                extension, params = extension.split(';', 1)
+                extension, params = extension
                 if extension == 'permessage-deflate':
-                    return [PerMessageDeflate(params)]
+                    return [PerMessageDeflate(False, params)]
         return []
 
     def process_subprotocol(self, get_header, available_subprotocols=None):

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -100,6 +100,15 @@ class ClientServerTests(unittest.TestCase):
         self.stop_client()
         self.stop_server()
 
+    def test_basic_no_compression(self):
+        self.start_server()
+        self.start_client(use_compression=False)
+        self.loop.run_until_complete(self.client.send("Hello!"))
+        reply = self.loop.run_until_complete(self.client.recv())
+        self.assertEqual(reply, "Hello!")
+        self.stop_client()
+        self.stop_server()
+
     def test_server_close_while_client_connected(self):
         self.start_server()
         self.start_client()

--- a/websockets/test_extensions.py
+++ b/websockets/test_extensions.py
@@ -1,0 +1,71 @@
+import unittest
+
+from websockets.extensions import parse_extensions
+
+
+class ExtensionParsingTests(unittest.TestCase):
+    def test_simple(self):
+        self.assert_parse_extensions('permessage-deflate', [
+            ('permessage-deflate', {})
+        ])
+
+    def test_one_extension_no_value(self):
+        self.assert_parse_extensions(
+            'permessage-deflate; client_max_window_bits', [
+                ('permessage-deflate', {'client_max_window_bits': None})
+            ])
+
+    def test_one_extension_value(self):
+        self.assert_parse_extensions(
+            'permessage-deflate; server_max_window_bits=10', [
+                ('permessage-deflate', {'server_max_window_bits': '10'})
+            ])
+
+    def test_one_extension_quoted_value(self):
+        self.assert_parse_extensions(
+            'permessage-deflate; server_max_window_bits="10"', [
+                ('permessage-deflate', {'server_max_window_bits': '10'})
+            ])
+
+    def test_one_extension_multiple_params(self):
+        self.assert_parse_extensions(
+            'permessage-deflate; option_a;option_b="10";option_c=foo',
+            [
+                ('permessage-deflate', {
+                    'option_a': None,
+                    'option_b': '10',
+                    'option_c': 'foo'
+                })
+            ])
+
+    def test_multi_extensions(self):
+        self.assert_parse_extensions(
+            'ext_one; option_a;option_b="10", ext_two, ext_three; foo; bar=42',
+            [
+                ('ext_one', {
+                    'option_a': None,
+                    'option_b': '10'
+                }),
+                ('ext_two', {}),
+                ('ext_three', {
+                    'foo': None,
+                    'bar': '42'
+                })
+            ])
+
+    def test_multi_line(self):
+        self.assert_parse_extensions(
+            '\next_one, \next_two, \n\next_three; foo; bar=42',
+            [
+                ('ext_one', {}),
+                ('ext_two', {}),
+                ('ext_three', {
+                    'foo': None,
+                    'bar': '42'
+                })
+            ])
+
+    @staticmethod
+    def assert_parse_extensions(header, expected):
+        result = parse_extensions(header)
+        assert result == expected

--- a/websockets/test_extensions.py
+++ b/websockets/test_extensions.py
@@ -1,6 +1,7 @@
 import unittest
 
-from websockets.extensions import parse_extensions
+from .extensions import PerMessageDeflate, parse_extensions
+from .framing import OP_CONT, OP_PING, OP_TEXT, Frame
 
 
 class ExtensionParsingTests(unittest.TestCase):
@@ -69,3 +70,154 @@ class ExtensionParsingTests(unittest.TestCase):
     def assert_parse_extensions(header, expected):
         result = parse_extensions(header)
         assert result == expected
+
+
+class PerMessageDeflateTests(unittest.TestCase):
+    def test_deflate_default(self):
+        server_deflate = PerMessageDeflate(False, {})
+        data = "Hello world".encode('utf-8')
+
+        frame = Frame(True, OP_TEXT, data)
+        frame = server_deflate.encode(frame)
+        self.assertTrue(frame.rsv1)
+        self.assertNotEqual(frame.data, data)
+
+        frame = server_deflate.decode(frame)
+        self.assertFalse(frame.rsv1)
+        self.assertEqual(frame.data, data)
+
+    def test_deflate_control(self):
+        server_deflate = PerMessageDeflate(False, {})
+
+        frame = Frame(True, OP_PING, b'foo')
+        encoded = server_deflate.encode(frame)
+        self.assertEqual(frame, encoded)
+
+        decoded = server_deflate.decode(encoded)
+        self.assertEqual(frame, decoded)
+
+    def test_deflate_decode_uncompressed(self):
+        server_deflate = PerMessageDeflate(False, {})
+        data = "Hello world".encode('utf-8')
+
+        frame = Frame(True, OP_TEXT, data)
+        frame = server_deflate.decode(frame)
+        self.assertEqual(frame.data, data)
+
+    def test_deflate_decode_uncompressed_fragments(self):
+        server_deflate = PerMessageDeflate(False, {})
+        data = "Hello world".encode('utf-8')
+
+        frame = Frame(True, OP_TEXT, data)
+        frag1 = server_deflate.decode(
+            frame._replace(fin=False, data=frame.data[:5])
+        )
+        frag2 = server_deflate.decode(
+            frame._replace(opcode=OP_CONT, data=frame.data[5:])
+        )
+        result = frag1.data + frag2.data
+        self.assertEqual(result, data)
+
+    def test_deflate_fragment(self):
+        server_deflate = PerMessageDeflate(False, {})
+        data = "I love websockets, especially RFC 7692".encode('utf-8')
+
+        frame = server_deflate.encode(Frame(True, OP_TEXT, data))
+        frag1 = server_deflate.decode(
+            frame._replace(fin=False, data=frame.data[:5])
+        )
+        frag2 = server_deflate.decode(
+            frame._replace(fin=False, rsv1=False, opcode=OP_CONT,
+                           data=frame.data[5:10])
+        )
+        frag3 = server_deflate.decode(
+            frame._replace(rsv1=False, opcode=OP_CONT, data=frame.data[10:])
+        )
+        result = frag1.data + frag2.data + frag3.data
+        self.assertEqual(result, data)
+
+    # Manually configured items
+
+    def test_deflate_response_server_no_context_takeover(self):
+        deflate = PerMessageDeflate(False, {}, server_no_context_takeover=True)
+        self.assertIn('server_no_context_takeover', deflate.response())
+
+    def test_deflate_response_client_no_context_takeover(self):
+        deflate = PerMessageDeflate(False, {}, client_no_context_takeover=True)
+        self.assertIn('client_no_context_takeover', deflate.response())
+
+    def test_deflate_response_client_max_window_bits(self):
+        deflate = PerMessageDeflate(False, {}, client_max_window_bits=10)
+        self.assertIn('client_max_window_bits=10', deflate.response())
+
+    def test_deflate_response_server_max_window_bits(self):
+        deflate = PerMessageDeflate(False, {}, server_max_window_bits=8)
+        self.assertIn('server_max_window_bits=8', deflate.response())
+
+    # Taking requested params into account
+
+    def test_deflate_server_max_window_bits_same(self):
+        deflate = PerMessageDeflate(False, {
+            'server_max_window_bits': 10
+        }, server_max_window_bits=10)
+        self.assertIn('server_max_window_bits=10', deflate.response())
+
+    def test_deflate_server_max_window_bits_higher(self):
+        deflate = PerMessageDeflate(False, {
+            'server_max_window_bits': 12
+        }, server_max_window_bits=10)
+        self.assertIn('server_max_window_bits=10', deflate.response())
+
+    def test_deflate_server_max_window_bits_lower(self):
+        deflate = PerMessageDeflate(False, {
+            'server_max_window_bits': 8
+        }, server_max_window_bits=10)
+        self.assertIn('server_max_window_bits=8', deflate.response())
+
+    def test_deflate_client_max_window_bits_same(self):
+        deflate = PerMessageDeflate(False, {
+            'client_max_window_bits': 10
+        }, client_max_window_bits=10)
+        self.assertIn('client_max_window_bits=10', deflate.response())
+
+    def test_deflate_client_max_window_bits_higher(self):
+        deflate = PerMessageDeflate(False, {
+            'client_max_window_bits': 12
+        }, client_max_window_bits=10)
+        self.assertIn('client_max_window_bits=10', deflate.response())
+
+    def test_deflate_client_max_window_bits_lower(self):
+        deflate = PerMessageDeflate(False, {
+            'client_max_window_bits': 8
+        }, client_max_window_bits=10)
+        self.assertIn('client_max_window_bits=8', deflate.response())
+
+    def test_deflate_server_no_context_takeover(self):
+        deflate = PerMessageDeflate(False, {
+            'server_no_context_takeover': None
+        })
+        self.assertIn('server_no_context_takeover', deflate.response())
+
+    def test_deflate_server_no_context_takeover_invalid(self):
+        with self.assertRaises(Exception):
+            PerMessageDeflate(False, {
+                'server_no_context_takeover': 42
+            })
+
+    def test_deflate_client_no_context_takeover(self):
+        deflate = PerMessageDeflate(False, {
+            'client_no_context_takeover': None
+        })
+        self.assertIn('client_no_context_takeover', deflate.response())
+
+    def test_deflate_client_no_context_takeover_invalid(self):
+        with self.assertRaises(Exception):
+            PerMessageDeflate(False, {
+                'client_no_context_takeover': 42
+            })
+
+    def test_deflate_invalid_parameter(self):
+        with self.assertRaises(Exception):
+            PerMessageDeflate(False, {
+                'websockets_are_great': 42
+            })

--- a/websockets/test_framing.py
+++ b/websockets/test_framing.py
@@ -155,14 +155,19 @@ class FramingTests(unittest.TestCase):
     @unittest.skipUnless(sys.version_info[:2] >= (3, 4), "rot13 is new in 3.4")
     def test_extensions(self):
 
-        # This extensions is symmetrical.
-        def rot13(frame):
-            assert frame.opcode == OP_TEXT
-            text = frame.data.decode()
-            data = codecs.encode(text, 'rot13').encode()
-            return frame._replace(data=data)
+        class Rot13:
+
+            @staticmethod
+            def encode(frame):
+                assert frame.opcode == OP_TEXT
+                text = frame.data.decode()
+                data = codecs.encode(text, 'rot13').encode()
+                return frame._replace(data=data)
+
+            # This extensions is symmetrical.
+            decode = encode
 
         self.round_trip(
             b'\x81\x05uryyb',
             Frame(True, OP_TEXT, b'hello'),
-            extensions=[rot13])
+            extensions=[Rot13()])


### PR DESCRIPTION
Implemented a first version of support for extension parameters.

You can force server side minimum parameters when instantiating the PerMessagDeflate class, which will allow users to configure their compression for server side.

Tested on autobahn tests 12.* 13.* while forcing server_max_window_bits=12, client_max_window_bits=10. All green!