### PR TITLE
Fix issue #142

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,11 @@ Changelog
   now raises :class:`~websockets.exceptions.InvalidStatus` with a ``code``
   attribute.
 
+* Fixed an issue where
+  :meth:`~websockets.protocol.WebSocketCommonProtocol.close` can return
+  without waiting for an underlying worker task to complete if
+  :meth:`~asyncio.Task.cancel` is called on it.
+
 3.3
 ...
 

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -261,9 +261,9 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
                 self.worker_task, self.timeout, loop=self.loop)
         except asyncio.TimeoutError:
             self.worker_task.cancel()
-
-        # The worker should terminate quickly once it has been cancelled.
-        yield from self.worker_task
+        finally:
+            # The worker should terminate quickly once it has been cancelled.
+            yield from self.worker_task
 
     @asyncio.coroutine
     def recv(self):

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -357,8 +357,8 @@ class ClientServerTests(unittest.TestCase):
         """
         class WorkerWaitedOn(Exception):
             pass
-
         tasks = []
+
         @asyncio.coroutine
         def patched_run():
             while not tasks:
@@ -382,7 +382,8 @@ class ClientServerTests(unittest.TestCase):
             with self.assertRaises(WorkerWaitedOn):
                 self.loop.run_until_complete(future)
         finally:
-            self.loop.run_until_complete(self.client.close_connection(force=True))
+            self.loop.run_until_complete(
+                self.client.close_connection(force=True))
 
     @with_server()
     @unittest.mock.patch('websockets.server.build_response')

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -368,11 +368,12 @@ class ClientServerTests(unittest.TestCase):
             close_task.cancel()
             try:
                 # Wait for the cancellation to kick in.
-                while True:
-                    yield from asyncio.sleep(0)
+                yield from asyncio.sleep(1)
             except asyncio.CancelledError:
                 # Simulate the worker taking time to finish.
                 yield from asyncio.sleep(0.1)
+            else:
+                raise RuntimeError('CancelledError not raised')
         _run.side_effect = patched_run
 
         self.start_client()

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -348,12 +348,12 @@ class ClientServerTests(unittest.TestCase):
 
     @with_server()
     @unittest.mock.patch('websockets.protocol.WebSocketCommonProtocol.run')
-    def test_issue_142(self, _run):
+    def test_client_worker_finished_when_close_cancelled(self, _run):
         """
-        Check that the underlying worker is finished if client.close()
-        is cancelled.
+        Check that the worker gets finished if client.close() is cancelled
+        while waiting on the worker.
 
-        This tests this issue:
+        This tests issue #142:
         https://github.com/aaugustin/websockets/issues/142
         """
         tasks = []


### PR DESCRIPTION
[Fix for issue #142] This issue was quite tricky for me to develop a test case for. The hardest part is that you need to find a way to call cancel on `close()` when it is at [this particular line of code](https://github.com/aaugustin/websockets/blob/5d361a361a31ce19896dd0fb2c9dc684514e2a09/websockets/protocol.py#L258). I was led to do that in a roundabout way.

I'm open to suggestions on ways to simplify the test or on ways to eliminate the need for sleeps (which could potentially lead to test flakiness, though the sleeps are quite large currently). Or if it's good enough for the time being, that's fine too!
