### PR TITLE
Address issue #116: make existing hook take place before the handshake

### DIFF
--- a/websockets/server.py
+++ b/websockets/server.py
@@ -66,7 +66,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         # it attemps to log relevant ones and close the connection properly.
         try:
             try:
-                response_headers = yield from self.pre_handshake(origins=self.origins)
+                response_headers = (
+                    yield from self.pre_handshake(origins=self.origins))
                 if response_headers is None:
                     # Then the response was already written.
                     return
@@ -275,7 +276,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         yield from self.close_connection(force=True)
 
     @asyncio.coroutine
-    def handshake(self, response_headers, subprotocols=None, extra_headers=None):
+    def handshake(self, response_headers, subprotocols=None,
+                  extra_headers=None):
         """
         Perform the server side of the opening handshake.
 
@@ -304,14 +306,16 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             set_header('Sec-WebSocket-Protocol', self.subprotocol)
         if extra_headers is not None:
             if callable(extra_headers):
-                extra_headers = extra_headers(self.path, self.raw_request_headers)
+                extra_headers = extra_headers(self.path,
+                                              self.raw_request_headers)
             if isinstance(extra_headers, collections.abc.Mapping):
                 extra_headers = extra_headers.items()
             for name, value in extra_headers:
                 set_header(name, value)
         build_response(set_header, key)
 
-        yield from self.write_http_response(SWITCHING_PROTOCOLS, response_headers)
+        yield from self.write_http_response(SWITCHING_PROTOCOLS,
+                                            response_headers)
 
         assert self.state == CONNECTING
         self.state = OPEN

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -247,7 +247,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
     @asyncio.coroutine
     def pre_handshake(self, origins=None):
         """
-        Handle the response, if possible, before the opening handshake.
+        Do pre-handshake response handling.
 
         If provided, ``origins`` is a list of acceptable HTTP Origin values.
         Include ``''`` if the lack of an origin is acceptable.

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -257,6 +257,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
 
         """
         yield from self.read_http_request()
+
         request_headers = self.request_headers
         get_header = lambda k: request_headers.get(k, '')
         self.origin = self.process_origin(get_header, origins)
@@ -269,7 +270,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         if status is None:
             return response_headers
 
-        yield from self.write_http_response(status, headers)
+        yield from self.write_http_response(status, response_headers)
         self.opening_handshake.set_result(False)
         yield from self.close_connection(force=True)
 

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -72,14 +72,13 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     # Then the response was already written.
                     return
 
-                try:
-                    yield from self.handshake(
-                        response_headers, subprotocols=self.subprotocols,
-                        extra_headers=self.extra_headers)
-                except ConnectionError as exc:
-                    logger.debug(
-                        "Connection error in opening handshake", exc_info=True)
-                    raise
+                yield from self.handshake(
+                    response_headers, subprotocols=self.subprotocols,
+                    extra_headers=self.extra_headers)
+            except ConnectionError as exc:
+                logger.debug(
+                    "Connection error in opening handshake", exc_info=True)
+                raise
             except Exception as exc:
                 if self._is_server_shutting_down(exc):
                     response = ('HTTP/1.1 503 Service Unavailable\r\n\r\n'

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -65,15 +65,20 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         # Since this method doesn't have a caller able to handle exceptions,
         # it attemps to log relevant ones and close the connection properly.
         try:
-
             try:
-                path = yield from self.handshake(
-                    origins=self.origins, subprotocols=self.subprotocols,
-                    extra_headers=self.extra_headers)
-            except ConnectionError as exc:
-                logger.debug(
-                    "Connection error in opening handshake", exc_info=True)
-                raise
+                response_headers = yield from self.pre_handshake(origins=self.origins)
+                if response_headers is None:
+                    # Then the response was already written.
+                    return
+
+                try:
+                    yield from self.handshake(
+                        response_headers, subprotocols=self.subprotocols,
+                        extra_headers=self.extra_headers)
+                except ConnectionError as exc:
+                    logger.debug(
+                        "Connection error in opening handshake", exc_info=True)
+                    raise
             except Exception as exc:
                 if self._is_server_shutting_down(exc):
                     response = ('HTTP/1.1 503 Service Unavailable\r\n\r\n'
@@ -89,13 +94,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                 self.writer.write(response.encode())
                 raise
 
-            # Subclasses can customize get_response_status() or handshake() to
-            # reject the handshake, typically after checking authentication.
-            if path is None:
-                return
-
             try:
-                yield from self.ws_handler(self, path)
+                yield from self.ws_handler(self, self.path)
             except Exception as exc:
                 if self._is_server_shutting_down(exc):
                     yield from self.fail_connection(1001)
@@ -234,21 +234,49 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         It is declared as a coroutine because such authentication checks are
         likely to require network requests.
 
-        The connection is closed immediately after sending the response when
-        the status code is not ``HTTPStatus.SWITCHING_PROTOCOLS``.
+        A return value of ``None`` means to continue to the opening
+        handshake, which would result in ``HTTPStatus.SWITCHING_PROTOCOLS``
+        on success. If the return value is not ``None``, the connection is
+        closed immediately after sending the response.
 
         Call ``set_header(key, value)`` to set additional response headers.
 
         """
-        return SWITCHING_PROTOCOLS
+        return None
 
     @asyncio.coroutine
-    def handshake(self, origins=None, subprotocols=None, extra_headers=None):
+    def pre_handshake(self, origins=None):
         """
-        Perform the server side of the opening handshake.
+        Handle the response, if possible, before the opening handshake.
 
         If provided, ``origins`` is a list of acceptable HTTP Origin values.
         Include ``''`` if the lack of an origin is acceptable.
+
+        Return the response headers so far, or None if the response has
+        already been handled.
+
+        """
+        yield from self.read_http_request()
+        request_headers = self.request_headers
+        get_header = lambda k: request_headers.get(k, '')
+        self.origin = self.process_origin(get_header, origins)
+
+        response_headers = []
+        set_header = lambda k, v: response_headers.append((k, v))
+        set_header('Server', USER_AGENT)
+
+        status = yield from self.get_response_status(set_header)
+        if status is None:
+            return response_headers
+
+        yield from self.write_http_response(status, headers)
+        self.opening_handshake.set_result(False)
+        yield from self.close_connection(force=True)
+
+    @asyncio.coroutine
+    def handshake(self, response_headers, subprotocols=None, extra_headers=None):
+        """
+        Perform the server side of the opening handshake.
 
         If provided, ``subprotocols`` is a list of supported subprotocols in
         order of decreasing preference.
@@ -263,47 +291,30 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         Return the URI of the request.
 
         """
-        path, headers = yield from self.read_http_request()
+        headers = self.request_headers
         get_header = lambda k: headers.get(k, '')
-
         key = check_request(get_header)
 
-        self.origin = self.process_origin(get_header, origins)
         self.subprotocol = self.process_subprotocol(get_header, subprotocols)
-
-        headers = []
-        set_header = lambda k, v: headers.append((k, v))
-
-        set_header('Server', USER_AGENT)
-
-        status = yield from self.get_response_status(set_header)
-
-        # Abort the connection if the status code isn't 101.
-        if status.value != SWITCHING_PROTOCOLS.value:
-            yield from self.write_http_response(status, headers)
-            self.opening_handshake.set_result(False)
-            yield from self.close_connection(force=True)
-            return
+        set_header = lambda k, v: response_headers.append((k, v))
 
         # Status code is 101, establish the connection.
         if self.subprotocol:
             set_header('Sec-WebSocket-Protocol', self.subprotocol)
         if extra_headers is not None:
             if callable(extra_headers):
-                extra_headers = extra_headers(path, self.raw_request_headers)
+                extra_headers = extra_headers(self.path, self.raw_request_headers)
             if isinstance(extra_headers, collections.abc.Mapping):
                 extra_headers = extra_headers.items()
             for name, value in extra_headers:
                 set_header(name, value)
         build_response(set_header, key)
 
-        yield from self.write_http_response(status, headers)
+        yield from self.write_http_response(SWITCHING_PROTOCOLS, response_headers)
 
         assert self.state == CONNECTING
         self.state = OPEN
         self.opening_handshake.set_result(True)
-
-        return path
 
 
 class WebSocketServer:

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -43,6 +43,7 @@ try:
     # Order by status code.
     UNAUTHORIZED = http.HTTPStatus.UNAUTHORIZED
     FORBIDDEN = http.HTTPStatus.FORBIDDEN
+    NOT_FOUND = http.HTTPStatus.NOT_FOUND
 except AttributeError:                                      # pragma: no cover
     class UNAUTHORIZED:
         value = 401
@@ -51,6 +52,10 @@ except AttributeError:                                      # pragma: no cover
     class FORBIDDEN:
         value = 403
         phrase = 'Forbidden'
+
+    class NOT_FOUND:
+        value = 404
+        phrase = 'Not Found'
 
 
 @contextmanager
@@ -309,7 +314,7 @@ class ClientServerTests(unittest.TestCase):
             @asyncio.coroutine
             def get_response_status(self, set_header):
                 if self.path != '/valid':
-                    return http.HTTPStatus.NOT_FOUND
+                    return NOT_FOUND
                 return (yield from super().get_response_status(set_header))
 
             @asyncio.coroutine

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -310,15 +310,12 @@ class ClientServerTests(unittest.TestCase):
             def get_response_status(self, set_header):
                 if self.path != '/valid':
                     return http.HTTPStatus.NOT_FOUND
-
-                status = yield from super().get_response_status(set_header)
-                return status
+                return (yield from super().get_response_status(set_header))
 
             @asyncio.coroutine
             def handshake(self, *args, **kwargs):
                 State.handshake_called = True
-                result = yield from super().handshake(*args, **kwargs)
-                return result
+                return (yield from super().handshake(*args, **kwargs))
 
         with self.temp_server(create_protocol=HandshakeStoringProtocol):
             with self.assertRaises(InvalidHandshake) as cm:

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -323,9 +323,9 @@ class ClientServerTests(unittest.TestCase):
                 return (yield from super().handshake(*args, **kwargs))
 
         with self.temp_server(create_protocol=HandshakeStoringProtocol):
-            with self.assertRaises(InvalidHandshake) as cm:
+            with self.assertRaises(InvalidStatus) as cm:
                 self.start_client(path='invalid')
-            self.assertEqual(str(cm.exception), 'Bad status code: 404')
+            self.assertEqual(cm.exception.code, 404)
             self.assertFalse(State.handshake_called)
             # Check that our overridden handshake() is working correctly.
             self.start_client(path='valid')


### PR DESCRIPTION
This is an illustration of what I proposed in [this comment](https://github.com/aaugustin/websockets/issues/116#issuecomment-313893781) to add a "pre-handshake" hook. All of the tests still pass (at least on my machine with 3.6.1).

If this approach is acceptable, I could make needed documentation changes, etc, and add a test of using the hook.