### PR TITLE
Fix issue #207: always set self.origin

### DIFF
--- a/websockets/server.py
+++ b/websockets/server.py
@@ -190,11 +190,11 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         acceptable.
 
         """
+        origin = get_header('Origin')
         if origins is not None:
-            origin = get_header('Origin')
             if origin not in origins:
                 raise InvalidOrigin("Origin not allowed: {}".format(origin))
-            return origin
+        return origin
 
     def process_subprotocol(self, get_header, subprotocols=None):
         """


### PR DESCRIPTION
This fixes issue #207.

It would be good if this could be committed before related PR's so the test can be present for the other PR's.
