### PR TITLE
Address issue #212: have coverage report missing line numbers.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands = python -m unittest
 commands =
     python -m coverage erase
     python -m coverage run --branch --source=websockets -m unittest
-    python -m coverage report --fail-under=100
+    python -m coverage report -m --fail-under=100
 deps = coverage
 
 [testenv:flake8]


### PR DESCRIPTION
Addresses issue #212.

The `-m` coverage option is documented [here](http://coverage.readthedocs.io/en/latest/cmd.html#coverage-summary).
