### PR TITLE
Don't rely on Python.h to include stdint.h in speedups.c

### DIFF
--- a/websockets/speedups.c
+++ b/websockets/speedups.c
@@ -2,6 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <stdint.h> /* uint32_t, uint64_t */
 
 #if __SSE2__
 #include <emmintrin.h>


### PR DESCRIPTION
The code in speedups.c relies on the assumption that Python.h includes
stdint.h
This might change in the future or might not be the case on some platforms so don’t rely on this assumption.