### PR TITLE
Replace modulo on signed integers by masking

### DIFF
--- a/websockets/speedups.c
+++ b/websockets/speedups.c
@@ -8,7 +8,7 @@
 #include <emmintrin.h>
 #endif
 
-const Py_ssize_t MASK_LEN = 4;
+static const Py_ssize_t MASK_LEN = 4;
 
 static PyObject *
 apply_mask(PyObject *self, PyObject *args, PyObject *kwds)
@@ -90,7 +90,7 @@ apply_mask(PyObject *self, PyObject *args, PyObject *kwds)
 
     for (; i < input_len; i++)
     {
-        output[i] = input[i] ^ mask[i % MASK_LEN];
+        output[i] = input[i] ^ mask[i & (MASK_LEN - 1)];
     }
 
     return result;


### PR DESCRIPTION
Compiler is not smart enough to know that both operands are positive &
optimize this with masking. We do what it should have been doing.
This is not critical given that only the remainder (at most 7 bytes) is impacted but nevertheless.