### PR TITLE
Update intersphinx_mapping setting.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,4 +256,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/3/': None}
+intersphinx_mapping = {'https://docs.python.org/3/': None}


### PR DESCRIPTION
When I run `make html` from the docs directory, the output shows this:

    Running Sphinx v1.6.3
    loading pickled environment... done
    loading intersphinx inventory from http://docs.python.org/3/objects.inv...
    intersphinx inventory has moved: http://docs.python.org/3/objects.inv ->
      https://docs.python.org/3/objects.inv
