### PR TITLE
Address issue #216: rename the klass argument to create_protocol.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,7 @@ Server
 
 .. automodule:: websockets.server
 
-   .. autofunction:: serve(ws_handler, host=None, port=None, *, klass=WebSocketServerProtocol, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None, origins=None, subprotocols=None, extra_headers=None, **kwds)
+   .. autofunction:: serve(ws_handler, host=None, port=None, *, create_protocol=None, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None, origins=None, subprotocols=None, extra_headers=None, **kwds)
 
    .. autoclass:: WebSocketServer
 
@@ -50,7 +50,7 @@ Client
 
 .. automodule:: websockets.client
 
-   .. autofunction:: connect(uri, *, klass=WebSocketClientProtocol, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None, origin=None, subprotocols=None, extra_headers=None, **kwds)
+   .. autofunction:: connect(uri, *, create_protocol=None, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None, origin=None, subprotocols=None, extra_headers=None, **kwds)
 
    .. autoclass:: WebSocketClientProtocol(*, host=None, port=None, secure=None, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 *In development*
 
+* Renamed :func:`~websockets.server.serve()` and
+  :func:`~websockets.client.connect()`'s ``klass`` argument to
+  ``create_protocol`` to reflect that it can also be a callable.
+  For backwards compatibility, ``klass`` is still supported.
+
 * :func:`~websockets.server.serve` can be used as an asynchronous context
   manager on Python ≥ 3.5.
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -22,9 +22,9 @@ Server
     execute the application logic, and finally closes the connection after
     the handler exits normally or with an exception.
 
-  * You may subclass :class:`~websockets.server.WebSocketServerProtocol` and
-    pass it or a factory function as the ``create_protocol`` argument for
-    advanced customization.
+  * For advanced customization, you may subclass
+    :class:`~websockets.server.WebSocketServerProtocol` and pass either this
+    subclass or a factory function as the ``create_protocol`` argument.
 
 Client
 ------
@@ -34,9 +34,9 @@ Client
 
   * On Python ≥ 3.5, you can also use it as an asynchronous context manager.
 
-  * You may subclass :class:`~websockets.server.WebSocketClientProtocol` and
-    pass it or a factory function as the ``create_protocol`` argument for
-    advanced customization.
+  * For advanced customization, you may subclass
+    :class:`~websockets.server.WebSocketClientProtocol` and pass either this
+    subclass or a factory function as the ``create_protocol`` argument.
 
 * Call :meth:`~websockets.protocol.WebSocketCommonProtocol.recv` and
   :meth:`~websockets.protocol.WebSocketCommonProtocol.send` to receive and

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -23,7 +23,8 @@ Server
     the handler exits normally or with an exception.
 
   * You may subclass :class:`~websockets.server.WebSocketServerProtocol` and
-    pass it in the ``klass`` keyword argument for advanced customization.
+    pass it or a factory function as the ``create_protocol`` argument for
+    advanced customization.
 
 Client
 ------
@@ -34,7 +35,8 @@ Client
   * On Python ≥ 3.5, you can also use it as an asynchronous context manager.
 
   * You may subclass :class:`~websockets.server.WebSocketClientProtocol` and
-    pass it in the ``klass`` keyword argument for advanced customization.
+    pass it or a factory function as the ``create_protocol`` argument for
+    advanced customization.
 
 * Call :meth:`~websockets.protocol.WebSocketCommonProtocol.recv` and
   :meth:`~websockets.protocol.WebSocketCommonProtocol.send` to receive and

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -407,10 +407,10 @@ class WebSocketServer:
 
 @asyncio.coroutine
 def serve(ws_handler, host=None, port=None, *,
-          create_protocol=None, klass=None,
+          create_protocol=None,
           timeout=10, max_size=2 ** 20, max_queue=2 ** 5,
           read_limit=2 ** 16, write_limit=2 ** 16,
-          loop=None, legacy_recv=False,
+          loop=None, legacy_recv=False, klass=None,
           origins=None, subprotocols=None, extra_headers=None,
           **kwds):
     """
@@ -440,10 +440,9 @@ def serve(ws_handler, host=None, port=None, *,
     set the ``ssl`` keyword argument to a :class:`~ssl.SSLContext` to enable
     TLS.
 
-    The ``create_protocol`` parameter allows customizing the
-    :class:`WebSocketServerProtocol` class used. The argument should be a
-    callable or class accepting the same arguments as
-    :class:`WebSocketServerProtocol` and that returns a
+    The ``create_protocol`` parameter allows customizing the asyncio protocol
+    that manages the connection. It should be a callable or class accepting
+    the same arguments as :class:`WebSocketServerProtocol` and returning a
     :class:`WebSocketServerProtocol` instance. It defaults to
     :class:`WebSocketServerProtocol`.
 
@@ -479,7 +478,13 @@ def serve(ws_handler, host=None, port=None, *,
     if loop is None:
         loop = asyncio.get_event_loop()
 
-    create_protocol = create_protocol or klass or WebSocketServerProtocol
+    # Backwards-compatibility: create_protocol used to be called klass.
+    # In the unlikely event that both are specified, klass is ignored.
+    if create_protocol is None:
+        create_protocol = klass
+
+    if create_protocol is None:
+        create_protocol = WebSocketServerProtocol
 
     ws_server = WebSocketServer(loop)
 

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -407,7 +407,7 @@ class WebSocketServer:
 
 @asyncio.coroutine
 def serve(ws_handler, host=None, port=None, *,
-          klass=WebSocketServerProtocol,
+          create_protocol=None, klass=None,
           timeout=10, max_size=2 ** 20, max_queue=2 ** 5,
           read_limit=2 ** 16, write_limit=2 ** 16,
           loop=None, legacy_recv=False,
@@ -439,6 +439,13 @@ def serve(ws_handler, host=None, port=None, *,
     :meth:`~asyncio.AbstractEventLoop.create_server`. For example, you can
     set the ``ssl`` keyword argument to a :class:`~ssl.SSLContext` to enable
     TLS.
+
+    The ``create_protocol`` parameter allows customizing the
+    :class:`WebSocketServerProtocol` class used. The argument should be a
+    callable or class accepting the same arguments as
+    :class:`WebSocketServerProtocol` and that returns a
+    :class:`WebSocketServerProtocol` instance. It defaults to
+    :class:`WebSocketServerProtocol`.
 
     The behavior of the ``timeout``, ``max_size``, and ``max_queue``,
     ``read_limit``, and ``write_limit`` optional arguments is described in the
@@ -472,10 +479,12 @@ def serve(ws_handler, host=None, port=None, *,
     if loop is None:
         loop = asyncio.get_event_loop()
 
+    create_protocol = create_protocol or klass or WebSocketServerProtocol
+
     ws_server = WebSocketServer(loop)
 
     secure = kwds.get('ssl') is not None
-    factory = lambda: klass(
+    factory = lambda: create_protocol(
         ws_handler, ws_server,
         host=host, port=port, secure=secure,
         timeout=timeout, max_size=max_size, max_queue=max_queue,


### PR DESCRIPTION
This addresses issue #216.

One minor note: you'll notice in the signatures that I made the default value `None` instead of the default class. The reason is that this makes the API somewhat friendlier when it comes to composing functions, etc. For example, if an end user defines a wrapper function and wants the same default, they can get the same default by passing `None`. They don't need to hard-code the default value in a second place. Secondarily, when it comes to deciding between `create_protocol` and `klass`, this makes it easier to know which arguments were explicitly passed.