### PR TITLE
Address issue #220: Build wheels on various platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+env:
+  global:
+#   Don't attempt to build Python 2.7 wheels; websockets only works on Python 3.
+    - CIBW_SKIP=cp27*
+#   Commented out because tests don't pass reliably on macOS, see #241.
+#    - CIBW_TEST_COMMAND="python3 -m unittest discover websockets"
+
+matrix:
+  include:
+    - dist: trusty
+      sudo: required
+      language: python
+      python: "3.3"
+      services:
+        - docker
+    - os: osx
+      osx_image: xcode8.3
+
+install:
+# Python 3 is needed to run cibuildwheel for websockets.
+  - if [ "${TRAVIS_OS_NAME:-}" == "osx" ]; then
+      brew install python3;
+    fi
+# Install cibuildwheel using pip3 to make sure Python 3 is used.
+  - pip3 install cibuildwheel==0.4.0
+# Create file '.cibuildwheel' so that extension build is not optional (c.f. setup.py).
+  - touch .cibuildwheel
+
+script:
+  - cibuildwheel --output-dir wheelhouse
+# Upload to PyPI on tags
+  - if [ "${TRAVIS_TAG:-}" != "" ]; then
+      python -m pip install twine &&
+      python -m twine upload --skip-existing wheelhouse/*;
+    fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+# Don't attempt to build Python 2.7 wheels; websockets only works on Python 3.
+  CIBW_SKIP: cp27*
+# Commented out because tests don't pass reliably on Windows, see #240.
+#  CIBW_TEST_COMMAND: python -m unittest discover websockets
+
+# Since Python 2 is still the default, invoke Python 3 explicitly.
+install:
+  - cmd: C:\Python33-x64\python.exe -m pip install cibuildwheel==0.4.0
+# Create file '.cibuildwheel' so that extension build is not optional (c.f. setup.py).
+  - cmd: touch .cibuildwheel
+build_script:
+  - cmd: C:\Python33-x64\python.exe -m cibuildwheel --output-dir wheelhouse
+# Upload to PyPI on tags
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
+        Invoke-Expression "python -m pip install twine"
+        Invoke-Expression "python -m twine upload --skip-existing wheelhouse/*.whl"
+      }

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ ext_modules = [
     setuptools.Extension(
         'websockets.speedups',
         sources=['websockets/speedups.c'],
-        optional=True,
+        optional=not os.path.exists(os.path.join(root_dir, '.cibuildwheel')),
     )
 ]
 


### PR DESCRIPTION
This is an attempt (WIP) to build wheels on various platforms using [cibuildwheel](https://github.com/joerick/cibuildwheel) on [travis-ci](https://travis-ci.org) & [appveyor](https://ci.appveyor.com)

So far, wheels are built on all platforms but nothing is done with them.
Results are here:
https://travis-ci.org/mayeut/websockets
https://ci.appveyor.com/project/mayeut/websockets

Known limitations:
- if the C extension build fails, a wheel will be built anyway as was the case for python 3.3 & 3.4 on Windows before 47b95195a28491ad4bfb0925560426bc38e7b8c0 (C extension configured as optional in setup.py)
- tests are not run because of failures
  - `test_close_handshake_timeout` fails on macOS with error `AssertionError: 0.03943201599997792 not less than 0.029 : Too slow: 0.03943201599997792 >= 0.029`
  - `test_server_receives_malformed_request` and `test_server_shuts_down_during_opening_handshake` fail on Windows with error `ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host`

I can't reproduce those issues (macOS is random, depends on short timings. I don't have a Windows VM available). Full call stacks can be found by following those links: [macOS](https://travis-ci.org/mayeut/websockets/jobs/259532227), [Windows](https://ci.appveyor.com/project/mayeut/websockets/build/3.3.13)

@aaugustin, this is just to get #220 started. Let me know what direction you want this to go to (if any).