### PR TITLE
Add process_request() to override request handling.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,8 +42,8 @@ Server
    .. autoclass:: WebSocketServerProtocol(ws_handler, ws_server, *, host=None, port=None, secure=None, timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, loop=None, origins=None, subprotocols=None, extra_headers=None)
 
         .. automethod:: handshake(origins=None, subprotocols=None, extra_headers=None)
+        .. automethod:: process_request(path, request_headers)
         .. automethod:: select_subprotocol(client_protos, server_protos)
-        .. automethod:: get_response_status()
 
 Client
 ......

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,8 +14,8 @@ Changelog
 * :func:`~websockets.server.serve` can be used as an asynchronous context
   manager on Python ≥ 3.5.
 
-* Added support for rejecting incoming connections by customizing
-  :meth:`~websockets.server.WebSocketServerProtocol.get_response_status()`.
+* Added support for customizing handling of incoming connections with
+  :meth:`~websockets.server.WebSocketServerProtocol.process_request()`.
 
 * Made read and write buffer sizes configurable.
 

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -30,7 +30,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
     @asyncio.coroutine
     def write_http_request(self, path, headers):
         """
-        Write status line and headers to the HTTP request.
+        Write request line and headers to the HTTP request.
 
         """
         self.path = path
@@ -52,7 +52,11 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         Read status line and headers from the HTTP response.
 
         Raise :exc:`~websockets.exceptions.InvalidMessage` if the HTTP message
-        is malformed or isn't a HTTP/1.1 GET request.
+        is malformed or isn't an HTTP/1.1 GET request.
+
+        Don't attempt to read the response body because WebSocket handshake
+        responses don't have one. If the response contains a body, it may be
+        read from ``self.reader`` after this coroutine returns.
 
         """
         try:

--- a/websockets/compatibility.py
+++ b/websockets/compatibility.py
@@ -12,6 +12,7 @@ try:                                                # pragma: no cover
                                                     # Python ≥ 3.5
     SWITCHING_PROTOCOLS = http.HTTPStatus.SWITCHING_PROTOCOLS
     # Used only in tests.
+    OK = http.HTTPStatus.OK
     UNAUTHORIZED = http.HTTPStatus.UNAUTHORIZED
     FORBIDDEN = http.HTTPStatus.FORBIDDEN
 except AttributeError:                              # pragma: no cover
@@ -19,6 +20,10 @@ except AttributeError:                              # pragma: no cover
     class SWITCHING_PROTOCOLS:
         value = 101
         phrase = "Switching Protocols"
+
+    class OK:
+        value = 200
+        phrase = "OK"
 
     class UNAUTHORIZED:
         value = 401

--- a/websockets/compatibility.py
+++ b/websockets/compatibility.py
@@ -11,10 +11,12 @@ except AttributeError:                              # pragma: no cover
 try:                                                # pragma: no cover
                                                     # Python ≥ 3.5
     SWITCHING_PROTOCOLS = http.HTTPStatus.SWITCHING_PROTOCOLS
-    # Used only in tests.
     OK = http.HTTPStatus.OK
+    BAD_REQUEST = http.HTTPStatus.BAD_REQUEST
     UNAUTHORIZED = http.HTTPStatus.UNAUTHORIZED
     FORBIDDEN = http.HTTPStatus.FORBIDDEN
+    INTERNAL_SERVER_ERROR = http.HTTPStatus.INTERNAL_SERVER_ERROR
+    SERVICE_UNAVAILABLE = http.HTTPStatus.SERVICE_UNAVAILABLE
 except AttributeError:                              # pragma: no cover
                                                     # Python < 3.5
     class SWITCHING_PROTOCOLS:
@@ -25,6 +27,10 @@ except AttributeError:                              # pragma: no cover
         value = 200
         phrase = "OK"
 
+    class BAD_REQUEST:
+        value = 400
+        phrase = "Bad Request"
+
     class UNAUTHORIZED:
         value = 401
         phrase = "Unauthorized"
@@ -32,3 +38,11 @@ except AttributeError:                              # pragma: no cover
     class FORBIDDEN:
         value = 403
         phrase = "Forbidden"
+
+    class INTERNAL_SERVER_ERROR:
+        value = 500
+        phrase = "Internal Server Error"
+
+    class SERVICE_UNAVAILABLE:
+        value = 503
+        phrase = "Service Unavailable"

--- a/websockets/exceptions.py
+++ b/websockets/exceptions.py
@@ -1,7 +1,7 @@
 __all__ = [
-    'InvalidHandshake', 'InvalidMessage', 'InvalidOrigin', 'InvalidState',
-    'InvalidStatusCode', 'InvalidURI', 'ConnectionClosed', 'PayloadTooBig',
-    'WebSocketProtocolError',
+    'AbortHandshake', 'InvalidHandshake', 'InvalidMessage', 'InvalidOrigin',
+    'InvalidState', 'InvalidStatusCode', 'InvalidURI', 'ConnectionClosed',
+    'PayloadTooBig', 'WebSocketProtocolError',
 ]
 
 
@@ -10,6 +10,17 @@ class InvalidHandshake(Exception):
     Exception raised when a handshake request or response is invalid.
 
     """
+
+
+class AbortHandshake(InvalidHandshake):
+    """
+    Exception raised to abort a handshake and return a HTTP response.
+
+    """
+    def __init__(self, status, headers, body=None):
+        self.status = status
+        self.headers = headers
+        self.body = body
 
 
 class InvalidMessage(InvalidHandshake):

--- a/websockets/http.py
+++ b/websockets/http.py
@@ -49,7 +49,7 @@ _value_re = re.compile(rb'^[\x09\x20-\x7e\x80-\xff]*$')
 @asyncio.coroutine
 def read_request(stream):
     """
-    Read an HTTP/1.1 request from ``stream``.
+    Read an HTTP/1.1 GET request from ``stream``.
 
     ``stream`` is an :class:`~asyncio.StreamReader`.
 
@@ -62,7 +62,9 @@ def read_request(stream):
 
     Raise an exception if the request isn't well formatted.
 
-    The request is assumed not to contain a body.
+    Don't attempt to read the request body because WebSocket handshake
+    requests don't have one. If the request contains a body, it may be
+    read from ``stream`` after this coroutine returns.
 
     """
     # https://tools.ietf.org/html/rfc7230#section-3.1.1
@@ -101,9 +103,11 @@ def read_response(stream):
 
     Non-ASCII characters are represented with surrogate escapes.
 
-    Raise an exception if the request isn't well formatted.
+    Raise an exception if the response isn't well formatted.
 
-    The response is assumed not to contain a body.
+    Don't attempt to read the response body, because WebSocket handshake
+    responses don't have one. If the response contains a body, it may be
+    read from ``stream`` after this coroutine returns.
 
     """
     # https://tools.ietf.org/html/rfc7230#section-3.1.2
@@ -134,7 +138,7 @@ def read_response(stream):
 @asyncio.coroutine
 def read_headers(stream):
     """
-    Read an HTTP message from ``stream``.
+    Read HTTP headers from ``stream``.
 
     ``stream`` is an :class:`~asyncio.StreamReader`.
 
@@ -142,8 +146,6 @@ def read_headers(stream):
     and ``headers`` is a list of ``(name, value)`` tuples.
 
     Non-ASCII characters are represented with surrogate escapes.
-
-    The message is assumed not to contain a body.
 
     """
     # https://tools.ietf.org/html/rfc7230#section-3.2

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -81,8 +81,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                 self.writer.write(response.encode())
                 raise
 
-            # Subclasses can customize get_response_status() or handshake() to
-            # reject the handshake, typically after checking authentication.
+            # Subclasses can customize process_request() to reject the
+            # handshake, typically after checking authentication.
             if path is None:
                 return
 
@@ -211,13 +211,22 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         return sorted(common_protos, key=priority)[0]
 
     @asyncio.coroutine
-    def get_response_status(self, set_header):
+    def process_request(self, path, request_headers):
         """
-        Return a :class:`~http.HTTPStatus` for the HTTP response.
+        Intercept the HTTP request and return a HTTP response if needed.
 
-        (:class:`~http.HTTPStatus` was added in Python 3.5. On earlier
-        versions, a compatible object must be returned. Check the definition
-        of ``SWITCHING_PROTOCOLS`` for an example.)
+        ``request_headers`` are a :class:`~http.client.HTTPMessage`.
+
+        If this coroutine returns ``None``, the WebSocket handshake continues.
+        If it returns a HTTP status code and HTTP headers, that HTTP response
+        is sent and the connection is closed immediately.
+
+        The HTTP status must be a :class:`~http.HTTPStatus` and HTTP headers
+        must be an iterable of ``(name, value)`` pairs.
+
+        (:class:`~http.HTTPStatus` was added in Python 3.5. Use a compatible
+        object on earlier versions. Look at ``SWITCHING_PROTOCOLS`` in
+        ``websockets.compatibility`` for an example.)
 
         This method may be overridden to check the request headers and set a
         different status, for example to authenticate the request and return
@@ -226,13 +235,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         It is declared as a coroutine because such authentication checks are
         likely to require network requests.
 
-        The connection is closed immediately after sending the response when
-        the status is not ``HTTPStatus.SWITCHING_PROTOCOLS``.
-
-        Call ``set_header(key, value)`` to set additional response headers.
-
         """
-        return SWITCHING_PROTOCOLS
 
     @asyncio.coroutine
     def handshake(self, origins=None, subprotocols=None, extra_headers=None):
@@ -255,29 +258,30 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         Return the URI of the request.
 
         """
-        path, headers = yield from self.read_http_request()
-        get_header = lambda k: headers.get(k, '')
+        path, request_headers = yield from self.read_http_request()
+
+        # Hook for customizing request handling, for example checking
+        # authentication or treating some paths as plain HTTP endpoints.
+
+        early_response = yield from self.process_request(path, request_headers)
+        if early_response is not None:
+            yield from self.write_http_response(*early_response)
+            self.opening_handshake.set_result(False)
+            yield from self.close_connection(force=True)
+            return
+
+        get_header = lambda k: request_headers.get(k, '')
 
         key = check_request(get_header)
 
         self.origin = self.process_origin(get_header, origins)
         self.subprotocol = self.process_subprotocol(get_header, subprotocols)
 
-        headers = []
-        set_header = lambda k, v: headers.append((k, v))
+        response_headers = []
+        set_header = lambda k, v: response_headers.append((k, v))
 
         set_header('Server', USER_AGENT)
 
-        status = yield from self.get_response_status(set_header)
-
-        # Abort the connection if the status code isn't 101.
-        if status.value != SWITCHING_PROTOCOLS.value:
-            yield from self.write_http_response(status, headers)
-            self.opening_handshake.set_result(False)
-            yield from self.close_connection(force=True)
-            return
-
-        # Status code is 101, establish the connection.
         if self.subprotocol:
             set_header('Sec-WebSocket-Protocol', self.subprotocol)
         if extra_headers is not None:
@@ -289,7 +293,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                 set_header(name, value)
         build_response(set_header, key)
 
-        yield from self.write_http_response(status, headers)
+        yield from self.write_http_response(
+            SWITCHING_PROTOCOLS, response_headers)
 
         assert self.state == CONNECTING
         self.state = OPEN

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -180,6 +180,34 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         if body is not None:
             self.writer.write(body)
 
+    @asyncio.coroutine
+    def process_request(self, path, request_headers):
+        """
+        Intercept the HTTP request and return an HTTP response if needed.
+
+        ``request_headers`` are a :class:`~http.client.HTTPMessage`.
+
+        If this coroutine returns ``None``, the WebSocket handshake continues.
+        If it returns a status code, headers and a optionally a response body,
+        that HTTP response is sent and the connection is closed.
+
+        The HTTP status must be a :class:`~http.HTTPStatus`. HTTP headers must
+        be an iterable of ``(name, value)`` pairs. If provided, the HTTP
+        response body must be :class:`bytes`.
+
+        (:class:`~http.HTTPStatus` was added in Python 3.5. Use a compatible
+        object on earlier versions. Look at ``SWITCHING_PROTOCOLS`` in
+        ``websockets.compatibility`` for an example.)
+
+        This method may be overridden to check the request headers and set a
+        different status, for example to authenticate the request and return
+        ``HTTPStatus.UNAUTHORIZED`` or ``HTTPStatus.FORBIDDEN``.
+
+        It is declared as a coroutine because such authentication checks are
+        likely to require network requests.
+
+        """
+
     def process_origin(self, get_header, origins=None):
         """
         Handle the Origin HTTP header.
@@ -218,34 +246,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             return None
         priority = lambda p: client_protos.index(p) + server_protos.index(p)
         return sorted(common_protos, key=priority)[0]
-
-    @asyncio.coroutine
-    def process_request(self, path, request_headers):
-        """
-        Intercept the HTTP request and return an HTTP response if needed.
-
-        ``request_headers`` are a :class:`~http.client.HTTPMessage`.
-
-        If this coroutine returns ``None``, the WebSocket handshake continues.
-        If it returns a status code, headers and a optionally a response body,
-        that HTTP response is sent and the connection is closed.
-
-        The HTTP status must be a :class:`~http.HTTPStatus`. HTTP headers must
-        be an iterable of ``(name, value)`` pairs. If provided, the HTTP
-        response body must be :class:`bytes`.
-
-        (:class:`~http.HTTPStatus` was added in Python 3.5. Use a compatible
-        object on earlier versions. Look at ``SWITCHING_PROTOCOLS`` in
-        ``websockets.compatibility`` for an example.)
-
-        This method may be overridden to check the request headers and set a
-        different status, for example to authenticate the request and return
-        ``HTTPStatus.UNAUTHORIZED`` or ``HTTPStatus.FORBIDDEN``.
-
-        It is declared as a coroutine because such authentication checks are
-        likely to require network requests.
-
-        """
 
     @asyncio.coroutine
     def handshake(self, origins=None, subprotocols=None, extra_headers=None):

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -134,12 +134,14 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
     @asyncio.coroutine
     def read_http_request(self):
         """
-        Read status line and headers from the HTTP request.
+        Read request line and headers from the HTTP request.
 
         Raise :exc:`~websockets.exceptions.InvalidMessage` if the HTTP message
-        is malformed or isn't a HTTP/1.1 GET request.
+        is malformed or isn't an HTTP/1.1 GET request.
 
-        This coroutine assumes that there is no request body.
+        Don't attempt to read the request body because WebSocket handshake
+        requests don't have one. If the request contains a body, it may be
+        read from ``self.reader`` after this coroutine returns.
 
         """
         try:
@@ -220,7 +222,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
     @asyncio.coroutine
     def process_request(self, path, request_headers):
         """
-        Intercept the HTTP request and return a HTTP response if needed.
+        Intercept the HTTP request and return an HTTP response if needed.
 
         ``request_headers`` are a :class:`~http.client.HTTPMessage`.
 

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -272,7 +272,7 @@ class ClientServerTests(unittest.TestCase):
     @with_server(create_protocol=HealthCheckServerProtocol)
     @with_client()
     def test_custom_protocol_http_request(self):
-        # One URL returns a HTTP response.
+        # One URL returns an HTTP response.
 
         if self.secure:
             url = 'https://localhost:8642/__health__/'

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -1,14 +1,16 @@
 import asyncio
+import contextlib
 import functools
 import logging
 import os
 import ssl
+import sys
 import unittest
 import unittest.mock
-from contextlib import contextmanager
+import urllib.request
 
 from .client import *
-from .compatibility import FORBIDDEN, UNAUTHORIZED
+from .compatibility import FORBIDDEN, OK, UNAUTHORIZED
 from .exceptions import ConnectionClosed, InvalidHandshake, InvalidStatusCode
 from .http import USER_AGENT, read_response
 from .server import *
@@ -38,7 +40,7 @@ def handler(ws, path):
         yield from ws.send((yield from ws.recv()))
 
 
-@contextmanager
+@contextlib.contextmanager
 def temp_test_server(test, **kwds):
     test.start_server(**kwds)
     try:
@@ -47,7 +49,7 @@ def temp_test_server(test, **kwds):
         test.stop_server()
 
 
-@contextmanager
+@contextlib.contextmanager
 def temp_test_client(test, *args, **kwds):
     test.start_client(*args, **kwds)
     try:
@@ -99,6 +101,15 @@ class ForbiddenServerProtocol(WebSocketServerProtocol):
         return FORBIDDEN, []
 
 
+class HealthCheckServerProtocol(WebSocketServerProtocol):
+
+    @asyncio.coroutine
+    def process_request(self, path, request_headers):
+        if path == '/__health__/':
+            body = b'status = green\n'
+            return OK, [('Content-Length', str(len(body)))], body
+
+
 class FooClientProtocol(WebSocketClientProtocol):
     pass
 
@@ -147,12 +158,12 @@ class ClientServerTests(unittest.TestCase):
         except asyncio.TimeoutError:                # pragma: no cover
             self.fail("Server failed to stop")
 
-    @contextmanager
+    @contextlib.contextmanager
     def temp_server(self, **kwds):
         with temp_test_server(self, **kwds):
             yield
 
-    @contextmanager
+    @contextlib.contextmanager
     def temp_client(self, *args, **kwds):
         with temp_test_client(self, *args, **kwds):
             yield
@@ -257,6 +268,38 @@ class ClientServerTests(unittest.TestCase):
         self.loop.run_until_complete(self.client.recv())
         resp_headers = self.loop.run_until_complete(self.client.recv())
         self.assertIn("('X-Spam', 'Eggs')", resp_headers)
+
+    @with_server(create_protocol=HealthCheckServerProtocol)
+    @with_client()
+    def test_custom_protocol_http_request(self):
+        # One URL returns a HTTP response.
+
+        if self.secure:
+            url = 'https://localhost:8642/__health__/'
+            if sys.version_info[:2] < (3, 4):               # pragma: no cover
+                # Python 3.3 didn't check SSL certificates.
+                open_health_check = functools.partial(
+                    urllib.request.urlopen, url)
+            else:                                           # pragma: no cover
+                open_health_check = functools.partial(
+                    urllib.request.urlopen, url, context=self.client_context)
+        else:
+            url = 'http://localhost:8642/__health__/'
+            open_health_check = functools.partial(
+                urllib.request.urlopen, url)
+
+        response = self.loop.run_until_complete(
+            self.loop.run_in_executor(None, open_health_check))
+
+        with contextlib.closing(response):
+            self.assertEqual(response.code, 200)
+            self.assertEqual(response.read(), b'status = green\n')
+
+        # Other URLs create a WebSocket connection.
+
+        self.loop.run_until_complete(self.client.send("Hello!"))
+        reply = self.loop.run_until_complete(self.client.recv())
+        self.assertEqual(reply, "Hello!")
 
     def assert_client_raises_code(self, status_code):
         with self.assertRaises(InvalidStatusCode) as raised:


### PR DESCRIPTION
This replaces the get_response_status() API which never made it into a
release (so there's no backwards incompatibility).

Remove a test that depends on get_response_status() being called after
check_request(). The extension point must be before check_request() so
it can handle regular HTTP requests.

Fix #116.

Supersedes #202 #154, #137.