### PR TITLE
Add PyPI and CircleCI badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-WebSockets
-==========
+WebSockets |pypi| |circleci|
+============================
 
 ``websockets`` is a library for developing WebSocket servers_ and clients_ in
 Python. It implements `RFC 6455`_ with a focus on correctness and simplicity.
@@ -26,3 +26,8 @@ Bug reports, patches and suggestions welcome! Just open an issue_ or send a
 .. _Read the Docs: https://websockets.readthedocs.io/
 .. _issue: https://github.com/aaugustin/websockets/issues/new
 .. _pull request: https://github.com/aaugustin/websockets/compare/
+
+.. |pypi| image:: https://img.shields.io/pypi/v/websockets.svg
+  :target: https://pypi.python.org/pypi/websockets
+.. |circleci| image:: https://circleci.com/gh/aaugustin/websockets/tree/master.svg?style=svg
+    :target: https://circleci.com/gh/aaugustin/websockets/tree/master


### PR DESCRIPTION
This reflects at first glance that this package is available on PyPI and that CI is in place.

I think that adding TravisCI and AppVeyor badges is not yet something that should be done. Not until wheels can be tested on those platforms.

In my opinion, a codecov badge wouldn't hurt as well c.f. #222. With that, at first glance, people will know package is available on PyPI, tested by CI and that coverage is 100%.

This, I think, is part of marketing tools (people knowing the project already know all of this).

Relates to #245