### PR TITLE
Add codecov to circleci.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,9 @@ machine:
 
 dependencies:
     override:
-        - pip install tox
+        - pip install tox codecov
 
 test:
     override:
         - tox
+        - codecov


### PR DESCRIPTION
Upload coverage results to `codecov` after `circleci` tests.

Overview here: https://codecov.io/gh/mayeut/websockets/tree/circleci-codecov/websockets

Python only for now.

Relates to #222, #245, #252 