### PR TITLE
Add C coverage using Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.so
+*.gcov
 .coverage
 .tox
 build/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,19 @@ coverage:
 	python -m coverage run --branch --source=websockets -m unittest
 	python -m coverage html
 
+nosse2.gcov: CFLAGS=-mno-sse2
+%.gcov: websockets/speedups.c
+	find . \( -name '*.so' -o -name '*.gcno' -o -name '*.gcda' \) -delete
+	CFLAGS="-O0 -coverage $(CFLAGS)" LDFLAGS="-coverage" python setup.py --quiet build_ext --inplace
+	python -m unittest
+	find . -name '*.gcda' -exec gcov -abcflp -o {} websockets/speedups.c \; > /dev/null
+	find . -name 'websockets#speedups.c.gcov' -exec mv {} $@ \;
+
+ccoverage: default.gcov nosse2.gcov
+	mkdir -p htmlcov
+	gcovr -g -r . -s -k --html --html-details -o htmlcov/speedups.html #'-k': keep gcov data
+
 clean:
-	find . -name '*.pyc' -o -name '*.so' -delete
+	find . \( -name '*.pyc' -o -name '*.so' -o -name '*.gcno' -o -name '*.gcda' -o -name '*.gcov' \) -delete
 	find . -name __pycache__ -delete
 	rm -rf .coverage build compliance/reports dist docs/_build htmlcov MANIFEST README websockets.egg-info

--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,11 @@ machine:
 
 dependencies:
     override:
-        - pip install tox codecov
+        - pip install codecov tox
 
 test:
     override:
         - tox
-        - codecov
+        - make default.gcov nosse2.gcov
+        - codecov -X gcov --required
+


### PR DESCRIPTION
This adds C coverage on Unix using the existing `Makefile`.

`circleci.yml` has been updated to run `gcov` file generation for upload in `codecov`.

Relates to #222 

There's another branch that does only part of this in `tox` (only one code path tested) c.f. mayeut/websockets@613eaed0113eeafa9643e329851c7fce446f4844. I feel that it's easier and more readable to do all code path tests in the `Makefile` here. Furthermore, we could add a check on coverage using a simple `grep` on `gcovr` output (requires `gcovr` to be added to `pip install` list in `circleci.yml`)