### PR TITLE
Remove futures & rework connection termination

### DIFF
--- a/websockets/client.py
+++ b/websockets/client.py
@@ -374,7 +374,7 @@ def connect(uri, *,
             extra_headers=protocol.extra_headers,
         )
     except Exception:
-        yield from protocol.close_connection(force=True)
+        yield from protocol.close_connection(after_handshake=False)
         raise
 
     return protocol

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -16,7 +16,7 @@ from .headers import (
     parse_protocol_list
 )
 from .http import USER_AGENT, build_headers, read_response
-from .protocol import CONNECTING, OPEN, WebSocketCommonProtocol
+from .protocol import WebSocketCommonProtocol
 from .uri import parse_uri
 
 
@@ -33,7 +33,6 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
     """
     is_client = True
     side = 'client'
-    state = CONNECTING
 
     def __init__(self, *,
                  origin=None, extensions=None, subprotocols=None,
@@ -267,9 +266,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         self.subprotocol = self.process_subprotocol(
             response_headers, available_subprotocols)
 
-        assert self.state == CONNECTING
-        self.state = OPEN
-        self.opening_handshake.set_result(True)
+        self.connection_open()
 
 
 @asyncio.coroutine

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -21,7 +21,7 @@ from .headers import (
     build_extension_list, parse_extension_list, parse_protocol_list
 )
 from .http import USER_AGENT, build_headers, read_request
-from .protocol import CONNECTING, OPEN, WebSocketCommonProtocol
+from .protocol import WebSocketCommonProtocol
 
 
 __all__ = ['serve', 'WebSocketServerProtocol']
@@ -42,7 +42,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
     """
     is_client = False
     side = 'server'
-    state = CONNECTING
 
     def __init__(self, ws_handler, ws_server, *,
                  origins=None, extensions=None, subprotocols=None,
@@ -118,7 +117,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     )
 
                 yield from self.write_http_response(*early_response)
-                self.opening_handshake.set_result(False)
                 yield from self.close_connection(force=True)
 
                 return
@@ -461,9 +459,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         yield from self.write_http_response(
             SWITCHING_PROTOCOLS, response_headers)
 
-        assert self.state == CONNECTING
-        self.state = OPEN
-        self.opening_handshake.set_result(True)
+        self.connection_open()
 
         return path
 


### PR DESCRIPTION
While trying to document the `opening_handshake` and `closing_handshake` futures, I discovered they didn't actually served a purpose.

`connection_closed` does serve a purpose, but I took this opportunity to reconsider how connections are closed. I reworked the implementation and fixed some RFC-compliance problems.