### PR TITLE
Fixed infinite loop in "Graceful Shutdown" Examples when client closed the connection

### DIFF
--- a/example/oldshutdown.py
+++ b/example/oldshutdown.py
@@ -9,7 +9,7 @@ async def echo(websocket, path):
         try:
             msg = await websocket.recv()
         except websockets.ConnectionClosed:
-            pass
+            break
         else:
             await websocket.send(msg)
 

--- a/example/shutdown.py
+++ b/example/shutdown.py
@@ -9,7 +9,7 @@ async def echo(websocket, path):
         try:
             msg = await websocket.recv()
         except websockets.ConnectionClosed:
-            pass
+            break
         else:
             await websocket.send(msg)
 


### PR DESCRIPTION
Replaced "pass" statement by "break" inside echo handler loop.
If a client closes connection it causes an infinite loop and took 100% CPU.
"websocket.recv()" always throws "websockets.ConnectionClosed" so "pass" statement just
continue loop over and over again.