### PR TITLE
Fix issue #309: server.wait_closed()

### DIFF
--- a/websockets/server.py
+++ b/websockets/server.py
@@ -572,13 +572,8 @@ class WebSocketServer:
         """
         # asyncio.wait doesn't accept an empty first argument.
         if self.websockets:
-            # Either the handler or the connection can terminate first,
-            # depending on how the client behaves and the server is
-            # implemented.
             yield from asyncio.wait(
-                [websocket.handler_task for websocket in self.websockets] +
-                [websocket.close_connection_task
-                    for websocket in self.websockets],
+                [websocket.handler_task for websocket in self.websockets],
                 loop=self.loop)
         yield from self.server.wait_closed()
 

--- a/websockets/test_client_server.py
+++ b/websockets/test_client_server.py
@@ -853,7 +853,9 @@ class ClientServerTests(unittest.TestCase):
     @asyncio.coroutine
     def test_server_wait_closed_with_process_request(self):
         try:
-            server = yield from serve(handler, 'localhost', 0, create_protocol=UnauthorizedServerProtocol)
+            server = (
+                yield from serve(handler, 'localhost', 0,
+                                 create_protocol=UnauthorizedServerProtocol))
             server_uri = get_server_uri(server)
             with self.assertRaises(InvalidStatusCode):
                 yield from connect(server_uri)


### PR DESCRIPTION
Fixes issue #309.