### PR TITLE
Emit a debug log message when ignoring unsolicited pongs.

### DIFF
--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -614,6 +614,8 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
                     while ping_id != frame.data:
                         ping_id, pong_waiter = self.pings.popitem(0)
                         pong_waiter.set_result(None)
+                else:
+                    logger.debug("%s ignoring unsolicited pong", self.side)
 
             # 5.6. Data Frames
             else:


### PR DESCRIPTION
An unsolicited pong likely indicates an error or misconfiguration, so it seems worth logging. I chose `debug`; you could make the argument for logging it at a higher log-level.