### PR TITLE
Use @asyncio.coroutine decorator on versions 3.5.0 and below.

### DIFF
--- a/websockets/server.py
+++ b/websockets/server.py
@@ -745,7 +745,7 @@ def unix_serve(ws_handler, path, **kwargs):
     return serve(ws_handler, path=path, **kwargs)
 
 
-if sys.version_info[:2] <= (3, 4):                          # pragma: no cover
+if sys.version_info[:3] <= (3, 5, 0):                     # pragma: no cover
     @asyncio.coroutine
     def serve(*args, **kwds):
         return Serve(*args, **kwds).__await__()


### PR DESCRIPTION
Changed in reference to: #318 
Tested and works with versions 3.5.0 and version 3.6.0
