### PR TITLE
Add zip_safe=True to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setuptools.setup(
     packages=packages,
     ext_modules=ext_modules,
     include_package_data=True,
-    zip_safe=True
+    zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -60,4 +60,5 @@ setuptools.setup(
     packages=packages,
     ext_modules=ext_modules,
     include_package_data=True,
+    zip_safe=True
 )


### PR DESCRIPTION
add `zip_safe=True` to setup.py to tell easy_install and setuptools that the code should not be analyzed before installing.
This avoids the problem caused by evaluating code in the /websockets/py36/ directory when running under Python 3.5.
Fixes #341 