### PR TITLE
Remove useless warning when closing a connection

### DIFF
--- a/websockets/exceptions.py
+++ b/websockets/exceptions.py
@@ -144,9 +144,9 @@ class ConnectionClosed(InvalidState):
         self.code = code
         self.reason = reason
         message = "WebSocket connection is closed: "
-        if 3000 <= code < 4000:
+        if code and 3000 <= code < 4000:
             explanation = "registered"
-        elif 4000 <= code < 5000:
+        elif code and 4000 <= code < 5000:
             explanation = "private use"
         else:
             explanation = CLOSE_CODES.get(code, "unknown")

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -510,7 +510,8 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         except PayloadTooBig:
             yield from self.fail_connection(1009)
         except Exception:
-            logger.warning("Error in data transfer", exc_info=True)
+            if self.state not in (State.CLOSING, State.CLOSED):
+                logger.warning("Error in data transfer", exc_info=True)
             yield from self.fail_connection(1011)
 
     @asyncio.coroutine


### PR DESCRIPTION
Websocket can print a useless warning while the connection closes if the other side closes the socket first (ConnectionResetError). This commit removes this warning if the state is CLOSING or CLOSED.