### PR TITLE
Disable async context manager functionality on Python 3.5.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 *In development*
 
 * :func:`~server.unix_serve` can be used as an asynchronous context manager on
-  Python ≥ 3.5.
+  Python ≥ 3.5.1.
 
 4.0
 ...
@@ -61,7 +61,7 @@ Also:
   For backwards compatibility, ``klass`` is still supported.
 
 * :func:`~server.serve` can be used as an asynchronous context manager on
-  Python ≥ 3.5.
+  Python ≥ 3.5.1.
 
 * Added support for customizing handling of incoming connections with
   :meth:`~server.WebSocketServerProtocol.process_request()`.
@@ -137,7 +137,7 @@ Also:
 Also:
 
 * :func:`~client.connect` can be used as an asynchronous context manager on
-  Python ≥ 3.5.
+  Python ≥ 3.5.1.
 
 * Updated documentation with ``await`` and ``async`` syntax from Python 3.5.
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -20,6 +20,8 @@ Server
 * Create a server with :func:`~server.serve` which is similar to asyncio's
   :meth:`~asyncio.AbstractEventLoop.create_server`.
 
+  * On Python ≥ 3.5.1, you can also use it as an asynchronous context manager.
+
   * The server takes care of establishing connections, then lets the handler
     execute the application logic, and finally closes the connection after the
     handler exits normally or with an exception.
@@ -34,7 +36,7 @@ Client
 * Create a client with :func:`~client.connect` which is similar to asyncio's
   :meth:`~asyncio.BaseEventLoop.create_connection`.
 
-  * On Python ≥ 3.5, you can also use it as an asynchronous context manager.
+  * On Python ≥ 3.5.1, you can also use it as an asynchronous context manager.
 
   * For advanced customization, you may subclass
     :class:`~server.WebSocketClientProtocol` and pass either this subclass or

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -40,8 +40,9 @@ Here's a full example (Unix-only):
 
 .. literalinclude:: ../example/shutdown.py
 
-``async``, ``await``, and asynchronous context managers aren't available in
-Python < 3.5. Here's the equivalent for older Python versions:
+``async`` and ``await`` were introduced in Python 3.5. websockets supports
+asynchronous context managers on Python ≥ 3.5.1. Here's the equivalent for
+older Python versions:
 
 .. literalinclude:: ../example/oldshutdown.py
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -3,22 +3,27 @@ Getting started
 
 .. currentmodule:: websockets
 
-.. warning::
-
-    This documentation is written for Python ≥ 3.5. If you're using Python
-    3.4, you will have to :ref:`adapt the code samples <python-lt-35>`.
-
 Installation
 ------------
 
-``websockets`` requires Python ≥ 3.4. Install it with::
+Install ``websockets`` with::
 
     pip install websockets
+
+``websockets`` requires Python ≥ 3.4. We recommend using the latest version.
+
+If you're using an older version, be aware that for each minor version (3.x),
+only the latest bugfix release (3.x.y) is officially supported.
+
+.. warning::
+
+    This documentation is written for Python ≥ 3.5.1. If you're using an older
+    Python version, you need to :ref:`adapt the code samples <python-lt-351>`.
 
 Basic example
 -------------
 
-*This section assumes Python ≥ 3.5. For older versions, read below.*
+*This section assumes Python ≥ 3.5.1. For older versions, read below.*
 
 .. _server-example:
 
@@ -37,8 +42,9 @@ Here's a corresponding client example.
 
 .. literalinclude:: ../example/client.py
 
-``async`` and ``await`` aren't available in Python < 3.5. Here's how to adapt
-the client example for older Python versions.
+``async`` and ``await`` were introduced in Python 3.5. websockets supports
++asynchronous context managers on Python ≥ 3.5.1. Here's how to adapt the
+client example for older Python versions.
 
 .. literalinclude:: ../example/oldclient.py
 
@@ -74,8 +80,8 @@ For receiving messages and passing them to a ``consumer`` coroutine::
 
 Iteration terminates when the client disconnects.
 
-Asynchronous iteration isn't available in Python < 3.6; here's the same code
-for earlier Python versions::
+Asynchronous iteration was introduced in Python 3.6; here's the same code for
+earlier Python versions::
 
     async def consumer_handler(websocket, path):
         while True:
@@ -153,15 +159,15 @@ answering pings, or any other behavior required by the specification.
 
 ``websockets`` handles all this under the hood so you don't have to.
 
-.. _python-lt-35:
+.. _python-lt-351:
 
-Python < 3.5
-------------
+Python < 3.5.1
+--------------
 
 This documentation uses the ``await`` and ``async`` syntax introduced in
 Python 3.5.
 
-If you're using Python 3.4, you must substitute::
+If you're using Python < 3.5, you must substitute::
 
     async def ...
 
@@ -179,3 +185,9 @@ with::
     yield from ...
 
 Otherwise you will encounter a :exc:`SyntaxError`.
+
+websockets supports asynchronous context managers only on Python ≥ 3.5.1
+because :func:`~asyncio.ensure_future` was changed to accept arbitrary
+awaitables in that version.
+
+If you're using Python ≤ 3.5, you can't use this feature.

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -280,7 +280,7 @@ class Connect:
     It yields a :class:`WebSocketClientProtocol` which can then be used to
     send and receive messages.
 
-    On Python ≥ 3.5, :func:`connect` can be used as a asynchronous context
+    On Python ≥ 3.5.1, :func:`connect` can be used as a asynchronous context
     manager. In that case, the connection is closed when exiting the context.
 
     :func:`connect` is a wrapper around the event loop's
@@ -409,7 +409,10 @@ class Connect:
     __iter__ = __await__
 
 
-if sys.version_info[:2] <= (3, 4):                          # pragma: no cover
+# Disable asynchronous context manager functionality only on Python < 3.5.1
+# because it doesn't exist on Python < 3.5 and asyncio.ensure_future didn't
+# accept arbitrary awaitables in Python 3.5; that was fixed in Python 3.5.1.
+if sys.version_info[:3] <= (3, 5, 0):                       # pragma: no cover
     @asyncio.coroutine
     def connect(*args, **kwds):
         return Connect(*args, **kwds).__await__()

--- a/websockets/py35/_test_client_server.py
+++ b/websockets/py35/_test_client_server.py
@@ -22,6 +22,9 @@ class ContextManagerTests(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
+    # Asynchronous context managers are only enabled on Python ≥ 3.5.1.
+    @unittest.skipIf(
+        sys.version_info[:3] <= (3, 5, 0), 'this test requires Python 3.5.1+')
     def test_client(self):
         start_server = serve(handler, 'localhost', 0)
         server = self.loop.run_until_complete(start_server)
@@ -39,6 +42,9 @@ class ContextManagerTests(unittest.TestCase):
         server.close()
         self.loop.run_until_complete(server.wait_closed())
 
+    # Asynchronous context managers are only enabled on Python ≥ 3.5.1.
+    @unittest.skipIf(
+        sys.version_info[:3] <= (3, 5, 0), 'this test requires Python 3.5.1+')
     def test_server(self):
         async def run_server():
             # Use serve as an asynchronous context manager.

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -744,7 +744,10 @@ def unix_serve(ws_handler, path, **kwargs):
     return serve(ws_handler, path=path, **kwargs)
 
 
-if sys.version_info[:2] <= (3, 4):                          # pragma: no cover
+# Disable asynchronous context manager functionality only on Python < 3.5.1
+# because it doesn't exist on Python < 3.5 and asyncio.ensure_future didn't
+# accept arbitrary awaitables in Python 3.5; that was fixed in Python 3.5.1.
+if sys.version_info[:3] <= (3, 5, 0):                       # pragma: no cover
     @asyncio.coroutine
     def serve(*args, **kwds):
         return Serve(*args, **kwds).__await__()


### PR DESCRIPTION
Clarify documentation about unsupported features in older Pythons.

Fix #318.