### PR TITLE
Better handle hard TCP connection termination.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,8 @@ Also:
 
 * Fixed missing close code, which caused :exc:`TypeError` on connection close.
 
+* Stopped logging stack traces when the TCP connection dies prematurely.
+
 4.0
 ...
 

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -517,7 +517,12 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             pass
         except WebSocketProtocolError:
             yield from self.fail_connection(1002)
-        except asyncio.IncompleteReadError:
+        except (ConnectionError, EOFError):
+            # Reading data with self.reader.readexactly may raise:
+            # - most subclasses of ConnectionError if the TCP connection
+            #   breaks, is reset, or is aborted;
+            # - IncompleteReadError, a subclass of EOFError, if fewer
+            #   bytes are available than requested.
             yield from self.fail_connection(1006)
         except UnicodeDecodeError:
             yield from self.fail_connection(1007)


### PR DESCRIPTION
There's no need to print a full stack trace when the network connection
dropped earlier than we expected. A 1006 close code is likely sufficient
to identify the cause if this is an issue in actual deployments.

Fix #348, #349.