### PR TITLE
Improve failing the WebSocket connection.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,8 @@ Also:
 
 * Stopped logging stack traces when the TCP connection dies prematurely.
 
+* Prevented writing to a closing TCP connection during unclean shutdowns.
+
 4.0
 ...
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,8 @@ Also:
 * If a :meth:`~protocol.WebSocketCommonProtocol.ping` doesn't receive a pong,
   it's cancelled when the connection is closed.
 
+* Reported the cause of :exc:`~exceptions.ConnectionClosed` exceptions.
+
 * Updated documentation with new features from Python 3.6.
 
 * Fixed missing close code, which caused :exc:`TypeError` on connection close.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,10 @@ Also:
 
 * Prevented writing to a closing TCP connection during unclean shutdowns.
 
+* Made connection termination more robust to network congestion.
+
+* Prevented processing of incoming frames after failing the connection.
+
 4.0
 ...
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -80,6 +80,10 @@ two tasks:
   connection. It must not be cancelled. It never exits with an exception. See
   :ref:`connection termination <connection-termination>` below.
 
+Besides, :meth:`~protocol.WebSocketCommonProtocol.fail_connection()` starts
+the same :attr:`~protocol.WebSocketCommonProtocol.close_connection_task` when
+the opening handshake fails, in order to close the TCP connection.
+
 Splitting the responsibilities between two tasks makes it easier to guarantee
 that ``websockets`` can terminate connections:
 

--- a/websockets/client.py
+++ b/websockets/client.py
@@ -404,7 +404,7 @@ class Connect:
                 extra_headers=protocol.extra_headers,
             )
         except Exception:
-            yield from protocol.close_connection(after_handshake=False)
+            yield from protocol.fail_connection()
             raise
 
         self.ws_client = protocol

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -134,7 +134,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     )
 
                 yield from self.write_http_response(*early_response)
-                yield from self.close_connection(after_handshake=False)
+                yield from self.fail_connection()
 
                 return
 
@@ -585,8 +585,7 @@ class WebSocketServer:
             yield from asyncio.wait(
                 [websocket.handler_task for websocket in self.websockets] +
                 [websocket.close_connection_task
-                    for websocket in self.websockets
-                    if websocket.close_connection_task],
+                    for websocket in self.websockets],
                 loop=self.loop)
         yield from self.server.wait_closed()
 

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -142,10 +142,12 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                 yield from self.ws_handler(self, path)
             except Exception as exc:
                 if self._is_server_shutting_down(exc):
-                    self.fail_connection(1001)
+                    if not self.closed:
+                        self.fail_connection(1001)
                 else:
                     logger.error("Error in connection handler", exc_info=True)
-                    self.fail_connection(1011)
+                    if not self.closed:
+                        self.fail_connection(1011)
                 raise
 
             try:

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -142,10 +142,10 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                 yield from self.ws_handler(self, path)
             except Exception as exc:
                 if self._is_server_shutting_down(exc):
-                    yield from self.fail_connection(1001)
+                    self.fail_connection(1001)
                 else:
                     logger.error("Error in connection handler", exc_info=True)
-                    yield from self.fail_connection(1011)
+                    self.fail_connection(1011)
                 raise
 
             try:

--- a/websockets/test_protocol.py
+++ b/websockets/test_protocol.py
@@ -742,8 +742,8 @@ class CommonTests:
         # Ensure the test terminates quickly.
         self.loop.call_later(MS, self.receive_eof_if_client)
 
-        # Simulate the situation where sending a close frame times out.
-        self.protocol.transfer_data_task.cancel()
+        # Simulate the case when close() times out sending a close frame.
+        self.protocol.fail_connection()
 
         with self.assertRaises(ConnectionClosed):
             self.loop.run_until_complete(self.protocol.ensure_open())


### PR DESCRIPTION
Mainly:

- Attach the reason why the connection was closed to ConnectionClosed exceptions
- Better mirror the specification in the implementation and improve compliance slightly in some edge cases
