### PR TITLE
Improve handling of HTTP requests.

### DIFF
--- a/websockets/compatibility.py
+++ b/websockets/compatibility.py
@@ -21,6 +21,7 @@ try:                                                # pragma: no cover
     BAD_REQUEST = http.HTTPStatus.BAD_REQUEST
     UNAUTHORIZED = http.HTTPStatus.UNAUTHORIZED
     FORBIDDEN = http.HTTPStatus.FORBIDDEN
+    UPGRADE_REQUIRED = http.HTTPStatus.UPGRADE_REQUIRED
     INTERNAL_SERVER_ERROR = http.HTTPStatus.INTERNAL_SERVER_ERROR
     SERVICE_UNAVAILABLE = http.HTTPStatus.SERVICE_UNAVAILABLE
 except AttributeError:                              # pragma: no cover
@@ -44,6 +45,10 @@ except AttributeError:                              # pragma: no cover
     class FORBIDDEN:
         value = 403
         phrase = "Forbidden"
+
+    class UPGRADE_REQUIRED:
+        value = 426
+        phrase = "Upgrade Required"
 
     class INTERNAL_SERVER_ERROR:
         value = 500

--- a/websockets/exceptions.py
+++ b/websockets/exceptions.py
@@ -1,9 +1,10 @@
 __all__ = [
-    'AbortHandshake', 'InvalidHandshake', 'InvalidHeader',
-    'InvalidHeaderFormat', 'InvalidMessage', 'InvalidOrigin', 'InvalidState',
-    'InvalidStatusCode', 'NegotiationError', 'InvalidParameterName',
-    'InvalidParameterValue', 'DuplicateParameter', 'InvalidURI',
-    'ConnectionClosed', 'PayloadTooBig', 'WebSocketProtocolError',
+    'AbortHandshake', 'ConnectionClosed', 'DuplicateParameter',
+    'InvalidHandshake', 'InvalidHeader', 'InvalidHeaderFormat',
+    'InvalidHeaderValue', 'InvalidMessage', 'InvalidOrigin',
+    'InvalidParameterName', 'InvalidParameterValue', 'InvalidState',
+    'InvalidStatusCode', 'InvalidUpgrade', 'InvalidURI', 'NegotiationError',
+    'PayloadTooBig', 'WebSocketProtocolError',
 ]
 
 
@@ -56,6 +57,20 @@ class InvalidHeaderFormat(InvalidHeader):
     def __init__(self, name, error, string, pos):
         error = "{} at {} in {}".format(error, pos, string)
         super().__init__(name, error)
+
+
+class InvalidHeaderValue(InvalidHeader):
+    """
+    Exception raised when a Sec-WebSocket-* HTTP header has a wrong value.
+
+    """
+
+
+class InvalidUpgrade(InvalidHeader):
+    """
+    Exception raised when a Upgrade or Connection header isn't correct.
+
+    """
 
 
 class InvalidOrigin(InvalidHeader):

--- a/websockets/exceptions.py
+++ b/websockets/exceptions.py
@@ -1,9 +1,9 @@
 __all__ = [
-    'AbortHandshake', 'InvalidHandshake', 'InvalidHeader', 'InvalidMessage',
-    'InvalidOrigin', 'InvalidState', 'InvalidStatusCode', 'NegotiationError',
-    'InvalidParameterName', 'InvalidParameterValue', 'DuplicateParameter',
-    'InvalidURI', 'ConnectionClosed', 'PayloadTooBig',
-    'WebSocketProtocolError',
+    'AbortHandshake', 'InvalidHandshake', 'InvalidHeader',
+    'InvalidHeaderFormat', 'InvalidMessage', 'InvalidOrigin', 'InvalidState',
+    'InvalidStatusCode', 'NegotiationError', 'InvalidParameterName',
+    'InvalidParameterValue', 'DuplicateParameter', 'InvalidURI',
+    'ConnectionClosed', 'PayloadTooBig', 'WebSocketProtocolError',
 ]
 
 
@@ -37,21 +37,34 @@ class InvalidMessage(InvalidHandshake):
 
 class InvalidHeader(InvalidHandshake):
     """
-    Exception raised when a HTTP header doesn't have the expected format.
+    Exception raised when a HTTP header doesn't have a valid format or value.
 
     """
-    def __init__(self, message, string, pos):
-        self.string = string
-        self.pos = pos
-        message = "{} at {} in {}".format(message, pos, string)
+    def __init__(self, name, value):
+        if value:
+            message = "Invalid {} header: {}".format(name, value)
+        else:
+            message = "Missing or empty {} header".format(name)
         super().__init__(message)
 
 
-class InvalidOrigin(InvalidHandshake):
+class InvalidHeaderFormat(InvalidHeader):
     """
-    Exception raised when the origin in a handshake request is forbidden.
+    Exception raised when a Sec-WebSocket-* HTTP header cannot be parsed.
 
     """
+    def __init__(self, name, error, string, pos):
+        error = "{} at {} in {}".format(error, pos, string)
+        super().__init__(name, error)
+
+
+class InvalidOrigin(InvalidHeader):
+    """
+    Exception raised when the Origin header in a request isn't allowed.
+
+    """
+    def __init__(self, origin):
+        super().__init__('Origin', origin)
 
 
 class InvalidStatusCode(InvalidHandshake):

--- a/websockets/handshake.py
+++ b/websockets/handshake.py
@@ -83,9 +83,7 @@ def check_request(get_header):
     """
     try:
         assert get_header('Upgrade').lower() == 'websocket'
-        assert any(
-            token.strip() == 'upgrade'
-            for token in get_header('Connection').lower().split(','))
+        assert get_header('Connection').lower() == 'upgrade'
         key = get_header('Sec-WebSocket-Key')
         assert len(base64.b64decode(key.encode(), validate=True)) == 16
         assert get_header('Sec-WebSocket-Version') == '13'
@@ -125,9 +123,7 @@ def check_response(get_header, key):
     """
     try:
         assert get_header('Upgrade').lower() == 'websocket'
-        assert any(
-            token.strip() == 'upgrade'
-            for token in get_header('Connection').lower().split(','))
+        assert get_header('Connection').lower() == 'upgrade'
         assert get_header('Sec-WebSocket-Accept') == accept(key)
     except Exception as exc:
         raise InvalidHandshake("Invalid response") from exc

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -10,11 +10,11 @@ import sys
 
 from .compatibility import (
     BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR, SERVICE_UNAVAILABLE,
-    SWITCHING_PROTOCOLS, asyncio_ensure_future
+    SWITCHING_PROTOCOLS, UPGRADE_REQUIRED, asyncio_ensure_future
 )
 from .exceptions import (
     AbortHandshake, InvalidHandshake, InvalidMessage, InvalidOrigin,
-    NegotiationError
+    InvalidUpgrade, NegotiationError
 )
 from .extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from .handshake import build_response, check_request
@@ -109,6 +109,13 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     early_response = (
                         FORBIDDEN,
                         [],
+                        str(exc).encode(),
+                    )
+                elif isinstance(exc, InvalidUpgrade):
+                    logger.debug("Invalid upgrade", exc_info=True)
+                    early_response = (
+                        UPGRADE_REQUIRED,
+                        [('Upgrade', 'websocket')],
                         str(exc).encode(),
                     )
                 elif isinstance(exc, InvalidHandshake):

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -96,7 +96,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     early_response = (
                         SERVICE_UNAVAILABLE,
                         [],
-                        b"Server is shutting down.",
+                        b"Server is shutting down.\n",
                     )
                 elif isinstance(exc, AbortHandshake):
                     early_response = (
@@ -109,28 +109,28 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     early_response = (
                         FORBIDDEN,
                         [],
-                        str(exc).encode(),
+                        (str(exc) + "\n").encode(),
                     )
                 elif isinstance(exc, InvalidUpgrade):
                     logger.debug("Invalid upgrade", exc_info=True)
                     early_response = (
                         UPGRADE_REQUIRED,
                         [('Upgrade', 'websocket')],
-                        str(exc).encode(),
+                        (str(exc) + "\n").encode(),
                     )
                 elif isinstance(exc, InvalidHandshake):
                     logger.debug("Invalid handshake", exc_info=True)
                     early_response = (
                         BAD_REQUEST,
                         [],
-                        str(exc).encode(),
+                        (str(exc) + "\n").encode(),
                     )
                 else:
                     logger.warning("Error in opening handshake", exc_info=True)
                     early_response = (
                         INTERNAL_SERVER_ERROR,
                         [],
-                        b"See server log for more information.",
+                        b"See server log for more information.\n",
                     )
 
                 yield from self.write_http_response(*early_response)

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -264,7 +264,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         origin = get_header('Origin')
         if origins is not None:
             if origin not in origins:
-                raise InvalidOrigin("Origin not allowed: {}".format(origin))
+                raise InvalidOrigin(origin)
         return origin
 
     @staticmethod

--- a/websockets/server.py
+++ b/websockets/server.py
@@ -105,14 +105,14 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                         exc.body,
                     )
                 elif isinstance(exc, InvalidOrigin):
-                    logger.warning("Invalid origin", exc_info=True)
+                    logger.debug("Invalid origin", exc_info=True)
                     early_response = (
                         FORBIDDEN,
                         [],
                         str(exc).encode(),
                     )
                 elif isinstance(exc, InvalidHandshake):
-                    logger.warning("Invalid handshake", exc_info=True)
+                    logger.debug("Invalid handshake", exc_info=True)
                     early_response = (
                         BAD_REQUEST,
                         [],

--- a/websockets/test_exceptions.py
+++ b/websockets/test_exceptions.py
@@ -20,18 +20,31 @@ class ExceptionsTests(unittest.TestCase):
                 "Malformed HTTP message",
             ),
             (
-                InvalidHeader('Upgrade', ''),
-                "Missing or empty Upgrade header",
+                InvalidHeader('Name', ''),
+                "Missing or empty Name header",
             ),
             (
-                InvalidHeader('Connection', 'websocket'),
-                "Invalid Connection header: websocket",
+                InvalidHeader('Name', 'Value'),
+                "Invalid Name header: Value",
             ),
             (
                 InvalidHeaderFormat(
                     'Sec-WebSocket-Protocol', "expected token", 'a=|', 3),
                 "Invalid Sec-WebSocket-Protocol header: "
                 "expected token at 3 in a=|",
+            ),
+            (
+                InvalidHeaderValue('Sec-WebSocket-Version', '42'),
+                "Invalid Sec-WebSocket-Version header: 42",
+            ),
+
+            (
+                InvalidUpgrade('Upgrade', ''),
+                "Missing or empty Upgrade header",
+            ),
+            (
+                InvalidUpgrade('Connection', 'websocket'),
+                "Invalid Connection header: websocket",
             ),
             (
                 InvalidOrigin('http://bad.origin'),

--- a/websockets/test_exceptions.py
+++ b/websockets/test_exceptions.py
@@ -20,12 +20,22 @@ class ExceptionsTests(unittest.TestCase):
                 "Malformed HTTP message",
             ),
             (
-                InvalidHeader("Expected token", "a=|", 3),
-                "Expected token at 3 in a=|",
+                InvalidHeader('Upgrade', ''),
+                "Missing or empty Upgrade header",
             ),
             (
-                InvalidOrigin("Origin not allowed: ''"),
-                "Origin not allowed: ''",
+                InvalidHeader('Connection', 'websocket'),
+                "Invalid Connection header: websocket",
+            ),
+            (
+                InvalidHeaderFormat(
+                    'Sec-WebSocket-Protocol', "expected token", 'a=|', 3),
+                "Invalid Sec-WebSocket-Protocol header: "
+                "expected token at 3 in a=|",
+            ),
+            (
+                InvalidOrigin('http://bad.origin'),
+                'Invalid Origin header: http://bad.origin',
             ),
             (
                 InvalidStatusCode(403),

--- a/websockets/test_handshake.py
+++ b/websockets/test_handshake.py
@@ -1,3 +1,4 @@
+import collections
 import contextlib
 import unittest
 
@@ -31,7 +32,7 @@ class HandshakeTests(unittest.TestCase):
         Assert that the transformation made them invalid.
 
         """
-        headers = {}
+        headers = collections.defaultdict(lambda: '')
         build_request(headers.__setitem__)
         yield headers
         with self.assertRaises(InvalidHandshake):
@@ -85,7 +86,7 @@ class HandshakeTests(unittest.TestCase):
         Assert that the transformation made them invalid.
 
         """
-        headers = {}
+        headers = collections.defaultdict(lambda: '')
         build_response(headers.__setitem__, key)
         yield headers
         with self.assertRaises(InvalidHandshake):

--- a/websockets/test_headers.py
+++ b/websockets/test_headers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from .exceptions import InvalidHeader
+from .exceptions import InvalidHeaderFormat
 from .headers import *
 
 
@@ -66,7 +66,7 @@ class HeadersTests(unittest.TestCase):
             'foo; bar=" "',
         ]:
             with self.subTest(header=header):
-                with self.assertRaises(InvalidHeader):
+                with self.assertRaises(InvalidHeaderFormat):
                     parse_extension_list(header)
 
     def test_parse_protocol_list(self):
@@ -101,5 +101,5 @@ class HeadersTests(unittest.TestCase):
             'foo; bar',
         ]:
             with self.subTest(header=header):
-                with self.assertRaises(InvalidHeader):
+                with self.assertRaises(InvalidHeaderFormat):
                     parse_protocol_list(header)


### PR DESCRIPTION
When receiving HTTP requests to WS endpoints:
- Avoid polluting logs at the warning level — but keep logs at the debug level because it must be possible to debug failures
- Return a HTTP 426 status code to plain HTTP requests