### PR TITLE
Don't treat close code 1001 as an error.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ Also:
 * :func:`~client.connect()` performs HTTP Basic Auth when the URI contains
   credentials.
 
+* Iterating on incoming messages no longer raises an exception when the
+  connection terminates with code 1001 (going away).
+
 * :func:`~server.unix_serve` can be used as an asynchronous context manager on
   Python ≥ 3.5.1.
 

--- a/websockets/protocol.py
+++ b/websockets/protocol.py
@@ -59,9 +59,9 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             await process(message)
 
     The iterator yields incoming messages. It exits normally when the
-    connection is closed with the status code 1000 OK. It raises a
-    :exc:`~websockets.exceptions.ConnectionClosed` exception when the
-    connection is closed with any other status code.
+    connection is closed with the status code 1000 (OK) or 1001 (going away).
+    It raises a :exc:`~websockets.exceptions.ConnectionClosed` exception when
+    the connection is closed with any other status code.
 
     The ``host``, ``port`` and ``secure`` parameters are simply stored as
     attributes for handlers that need them.

--- a/websockets/py36/protocol.py
+++ b/websockets/py36/protocol.py
@@ -14,7 +14,7 @@ async def __aiter__(self):
         while True:
             yield await self.recv()
     except ConnectionClosed as exc:
-        if exc.code == 1000:
+        if exc.code == 1000 or exc.code == 1001:
             return
         else:
             raise


### PR DESCRIPTION
Quite often, browsers close WebSocket connections when the user
navigates to another page. In most cases this isn't an error
condition and thus not worth reporting with an exception.