### PR TITLE
Prevent duplicate AppVeyor builds.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,9 @@
+branches:
+  only:
+    - master
+
+skip_branch_with_pr: true
+
 environment:
 # websockets only works on Python >= 3.4.
   CIBW_SKIP: cp27-* cp33-*


### PR DESCRIPTION
This was configured in the UI, however the UI is ignored when there's a
YAML config file.