### PR TITLE
Simplify connection termination on server shutdown.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,23 @@ Changelog
 
 .. warning::
 
+    **Version 7.0 changes how a server terminates connections when it's
+    closed with :meth:`~websockets.server.WebSocketServer.close`.**
+
+    Previously, connections handlers were canceled. Now, connections are
+    closed with close code 1001 (going away). From the perspective of the
+    connection handler, this is the same as if the remote endpoint was
+    disconnecting. This removes the need to prepare for
+    :exc:`~asyncio.CancelledError` in connection handlers.
+
+    You can restore the previous behavior by adding the following line at the
+    beginning of connection handlers::
+
+        def handler(ws, path):
+            ws.wait_closed().add_done_callback(asyncio.current_task().cancel)
+
+.. warning::
+
     **Version 7.0 changes how a** :meth:`~protocol.WebSocketCommonProtocol.ping`
     **that hasn't received a pong yet behaves when the connection is closed.**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -108,7 +108,7 @@ Also:
   credentials.
 
 * Iterating on incoming messages no longer raises an exception when the
-  connection terminates with code 1001 (going away).
+  connection terminates with close code 1001 (going away).
 
 * A plain HTTP request now receives a 426 Upgrade Required response and
   doesn't log a stack trace.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,26 +10,27 @@ Changelog
 
 .. warning::
 
-  **Version 7.0 renames the** ``timeout`` **argument of**
-  :func:`~server.serve()` **and** :func:`~client.connect()` **to**
-  ``close_timeout`` **.**
+    **Version 7.0 renames the** ``timeout`` **argument of**
+    :func:`~server.serve()` **and** :func:`~client.connect()` **to**
+    ``close_timeout`` **.**
 
-  This prevents confusion with ``ping_timeout``.
+    This prevents confusion with ``ping_timeout``.
 
-  For backwards compatibility, ``timeout`` is still supported.
+    For backwards compatibility, ``timeout`` is still supported.
 
 .. warning::
 
-  **Version 7.0 changes how a** :meth:`~protocol.WebSocketCommonProtocol.ping`
-  **that hasn't received a pong yet behaves when the connection is closed.**
+    **Version 7.0 changes how a** :meth:`~protocol.WebSocketCommonProtocol.ping`
+    **that hasn't received a pong yet behaves when the connection is closed.**
 
-  The ping — as in ``ping = await websocket.ping()`` — used to be canceled
-  when the connection is closed, so that ``await ping`` raised
-  :exc:`~concurrent.futures.CancelledError`. Now ``await ping`` raises
-  :exc:`~exceptions.ConnectionClosed` like other public APIs.
+    The ping — as in ``ping = await websocket.ping()`` — used to be canceled
+    when the connection is closed, so that ``await ping`` raised
+    :exc:`~asyncio.CancelledError`. Now ``await ping`` raises
+    :exc:`~exceptions.ConnectionClosed` like other public APIs.
 
 * websockets sends Ping frames at regular intervals and closes the connection
-  if it doesn't receive a matching Pong frame. See :class:`~protocol.WebSocketCommonProtocol` for details.
+  if it doesn't receive a matching Pong frame. See
+  :class:`~protocol.WebSocketCommonProtocol` for details.
 
 * Added support for sending fragmented messages.
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -13,6 +13,15 @@ Server
     :meth:`~protocol.WebSocketCommonProtocol.send` to receive and send
     messages at any time.
 
+  * When :meth:`~protocol.WebSocketCommonProtocol.recv` or
+    :meth:`~protocol.WebSocketCommonProtocol.send` raises
+    :exc:`~exceptions.ConnectionClosed`, clean up and exit. If you started
+    other :class:`asyncio.Task`, terminate them before exiting.
+
+  * If you aren't awaiting :meth:`~protocol.WebSocketCommonProtocol.recv`,
+    consider awaiting :meth:`~protocol.WebSocketCommonProtocol.wait_closed`
+    to detect quickly when the connection is closed.
+
   * You may :meth:`~protocol.WebSocketCommonProtocol.ping` or
     :meth:`~protocol.WebSocketCommonProtocol.pong` if you wish but it isn't
     needed in general.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -77,7 +77,7 @@ two tasks:
 - :attr:`~protocol.WebSocketCommonProtocol.keepalive_ping_task` runs
   :meth:`~protocol.WebSocketCommonProtocol.keepalive_ping()` which sends Ping
   frames at regular intervals and ensures that corresponding Pong frames are
-  received. It is cancelled when the connection terminates. It never exits
+  received. It is canceled when the connection terminates. It never exits
   with an exception other than :exc:`~asyncio.CancelledError`.
 
 - :attr:`~protocol.WebSocketCommonProtocol.close_connection_task` runs

--- a/src/websockets/exceptions.py
+++ b/src/websockets/exceptions.py
@@ -1,5 +1,6 @@
 __all__ = [
     'AbortHandshake',
+    'CancelHandshake',
     'ConnectionClosed',
     'DuplicateParameter',
     'InvalidHandshake',
@@ -41,6 +42,13 @@ class AbortHandshake(InvalidHandshake):
             status, len(headers), len(body)
         )
         super().__init__(message)
+
+
+class CancelHandshake(InvalidHandshake):
+    """
+    Exception raised to cancel a handshake when the connection is closed.
+
+    """
 
 
 class InvalidMessage(InvalidHandshake):

--- a/src/websockets/framing.py
+++ b/src/websockets/framing.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 DATA_OPCODES = OP_CONT, OP_TEXT, OP_BINARY = 0x00, 0x01, 0x02
-CTRL_OPCODES = OP_CLOSE, OP_PING, OP_PONG = 0x08, 0x09, 0x0a
+CTRL_OPCODES = OP_CLOSE, OP_PING, OP_PONG = 0x08, 0x09, 0x0A
 
 # Close code that are allowed in a close frame.
 # Using a list optimizes `code in EXTERNAL_CLOSE_CODES`.

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -960,7 +960,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         except asyncio.CancelledError:
             raise
 
-        except Exception as exc:
+        except Exception:
             logger.warning("Unexpected exception in keepalive ping task", exc_info=True)
 
     @asyncio.coroutine

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -76,7 +76,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             await process(message)
 
     The iterator yields incoming messages. It exits normally when the
-    connection is closed with the status code 1000 (OK) or 1001 (going away).
+    connection is closed with the close code 1000 (OK) or 1001 (going away).
     It raises a :exc:`~websockets.exceptions.ConnectionClosed` exception when
     the connection is closed with any other status code.
 

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -352,9 +352,10 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         """
         return self.state is State.CLOSED
 
+    @asyncio.coroutine
     def wait_closed(self):
         """
-        Return a :class:`asyncio.Future` that completes when the connection is closed.
+        Wait until the connection is closed.
 
         This is identical to :attr:`closed`, except it can be awaited.
 
@@ -362,7 +363,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         of its cause, in tasks that interact with the WebSocket connection.
 
         """
-        return asyncio.shield(self.connection_lost_waiter)
+        yield from asyncio.shield(self.connection_lost_waiter)
 
     @asyncio.coroutine
     def recv(self):

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -1072,7 +1072,11 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
 
         """
         logger.debug(
-            "%s ! failing WebSocket connection: %d %s", self.side, code, reason
+            "%s ! failing WebSocket connection in the %s state: %d %s",
+            self.side,
+            self.state.name,
+            code,
+            reason or '[no reason]',
         )
 
         # Cancel transfer_data_task if the opening handshake succeeded.
@@ -1199,7 +1203,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
             "%s x code = %d, reason = %s",
             self.side,
             self.close_code,
-            self.close_reason or '[empty]',
+            self.close_reason or '[no reason]',
         )
         self.abort_keepalive_pings()
         # If self.connection_lost_waiter isn't pending, that's a bug, because:

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -941,9 +941,9 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
 
                 # ping() cannot raise ConnectionClosed, only CancelledError:
                 # - If the connection is CLOSING, keepalive_ping_task will be
-                #   cancelled by close_connection() before ping() returns.
+                #   canceled by close_connection() before ping() returns.
                 # - If the connection is CLOSED, keepalive_ping_task must be
-                #   cancelled already.
+                #   canceled already.
                 ping_waiter = yield from self.ping()
 
                 if self.ping_timeout is not None:

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -14,13 +14,13 @@ from .compatibility import (
     BAD_REQUEST,
     FORBIDDEN,
     INTERNAL_SERVER_ERROR,
-    SERVICE_UNAVAILABLE,
     SWITCHING_PROTOCOLS,
     UPGRADE_REQUIRED,
     asyncio_ensure_future,
 )
 from .exceptions import (
     AbortHandshake,
+    CancelHandshake,
     InvalidHandshake,
     InvalidHeader,
     InvalidMessage,
@@ -32,7 +32,7 @@ from .extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from .handshake import build_response, check_request
 from .headers import build_extension_list, parse_extension_list, parse_subprotocol_list
 from .http import USER_AGENT, Headers, MultipleValuesError, read_request
-from .protocol import WebSocketCommonProtocol
+from .protocol import State, WebSocketCommonProtocol
 
 
 __all__ = ['serve', 'unix_serve', 'WebSocketServerProtocol']
@@ -97,7 +97,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         Handle the lifecycle of a WebSocket connection.
 
         Since this method doesn't have a caller able to handle exceptions, it
-        attemps to log relevant ones and close the connection properly.
+        attemps to log relevant ones and guarantees that the TCP connection is
+        closed before exiting.
 
         """
         try:
@@ -109,17 +110,14 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     available_subprotocols=self.available_subprotocols,
                     extra_headers=self.extra_headers,
                 )
-            except ConnectionError as exc:
+            except ConnectionError:
                 logger.debug("Connection error in opening handshake", exc_info=True)
                 raise
+            except CancelHandshake:
+                yield from self.fail_connection()
+                return
             except Exception as exc:
-                if self._is_server_shutting_down(exc):
-                    status, headers, body = (
-                        SERVICE_UNAVAILABLE,
-                        [],
-                        b"Server is shutting down.\n",
-                    )
-                elif isinstance(exc, AbortHandshake):
+                if isinstance(exc, AbortHandshake):
                     status, headers, body = exc.status, exc.headers, exc.body
                 elif isinstance(exc, InvalidOrigin):
                     logger.debug("Invalid origin", exc_info=True)
@@ -157,29 +155,23 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
 
                 yield from self.write_http_response(status, headers, body)
                 yield from self.fail_connection()
-
                 return
 
             try:
                 yield from self.ws_handler(self, path)
-            except Exception as exc:
-                if self._is_server_shutting_down(exc):
-                    if not self.closed:
-                        self.fail_connection(1001)
-                else:
-                    logger.error("Error in connection handler", exc_info=True)
-                    if not self.closed:
-                        self.fail_connection(1011)
+            except Exception:
+                logger.error("Error in connection handler", exc_info=True)
+                if not self.closed:
+                    self.fail_connection(1011)
                 raise
 
             try:
                 yield from self.close()
-            except ConnectionError as exc:
+            except ConnectionError:
                 logger.debug("Connection error in closing handshake", exc_info=True)
                 raise
-            except Exception as exc:
-                if not self._is_server_shutting_down(exc):
-                    logger.warning("Error in closing handshake", exc_info=True)
+            except Exception:
+                logger.warning("Error in closing handshake", exc_info=True)
                 raise
 
         except Exception:
@@ -195,13 +187,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             # task because the server waits for tasks attached to registered
             # connections before terminating.
             self.ws_server.unregister(self)
-
-    def _is_server_shutting_down(self, exc):
-        """
-        Decide whether an exception means that the server is shutting down.
-
-        """
-        return isinstance(exc, asyncio.CancelledError) and self.ws_server.closing
 
     @asyncio.coroutine
     def read_http_request(self):
@@ -467,8 +452,14 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
 
         # Hook for customizing request handling, for example checking
         # authentication or treating some paths as plain HTTP endpoints.
-
         early_response = yield from self.process_request(path, request_headers)
+
+        # Give up immediately and don't attempt to write a HTTP response if
+        # the TCP connection was closed while process_request() was running.
+        # This happens if the server shuts down and calls fail_connection().
+        if self.state != State.CONNECTING:
+            raise CancelHandshake()
+
         if early_response is not None:
             raise AbortHandshake(*early_response)
 
@@ -538,8 +529,14 @@ class WebSocketServer:
         # Store a reference to loop to avoid relying on self.server._loop.
         self.loop = loop
 
-        self.closing = False
+        # Keep track of active connections.
         self.websockets = set()
+
+        # Task responsible for closing the server and terminating connections.
+        self.close_task = None
+
+        # Completed when the server is closed and connections are terminated.
+        self.closed_waiter = asyncio.Future(loop=loop)
 
     def wrap(self, server):
         """
@@ -574,53 +571,65 @@ class WebSocketServer:
 
     def close(self):
         """
-        Close the underlying server, and clean up connections.
+        Close the server and terminate connections with close code 1001.
 
-        This calls :meth:`~asyncio.Server.close` on the underlying
-        :class:`~asyncio.Server` object, closes open connections with
-        status code 1001, and stops accepting new connections.
+        This method is idempotent.
 
         """
-        # Make a note that the server is shutting down. Websocket connections
-        # check this attribute to decide to send a "going away" close code.
-        self.closing = True
+        if self.close_task is None:
+            self.close_task = asyncio_ensure_future(self._close(), loop=self.loop)
 
+    @asyncio.coroutine
+    def _close(self):
+        """
+        Implementation of :meth:`close`.
+
+        This calls :meth:`~asyncio.Server.close` on the underlying
+        :class:`~asyncio.Server` object to stop accepting new connections and
+        then closes open connections with close code 1001.
+
+        """
         # Stop accepting new connections.
         self.server.close()
 
-        # Close open connections. For each connection, two tasks are running:
-        # 1. self.transfer_data_task receives incoming WebSocket messages
-        # 2. self.handler_task runs the opening handshake, the handler provided
-        #    by the user and the closing handshake
-        # In the general case, cancelling the handler task will cause the
-        # handler provided by the user to exit with a CancelledError, which
-        # will then cause the transfer data task to terminate.
+        # Wait until self.server.close() completes.
+        yield from self.server.wait_closed()
+
+        # Wait until all accepted connections reach connection_made() and call
+        # register(). See https://bugs.python.org/issue34852 for details.
+        yield from asyncio.sleep(0)
+
+        # Close open connections. fail_connection() will cancel the transfer
+        # data task, which is expected to cause the handler task to terminate.
         for websocket in self.websockets:
-            websocket.handler_task.cancel()
+            websocket.fail_connection(1001)
 
-    @asyncio.coroutine
-    def wait_closed(self):
-        """
-        Wait until the underlying server and all connections are closed.
-
-        This calls :meth:`~asyncio.Server.wait_closed` on the underlying
-        :class:`~asyncio.Server` object and waits until closing handshakes
-        are complete and all connections are closed.
-
-        This method must be called after :meth:`close()`.
-
-        """
         # asyncio.wait doesn't accept an empty first argument.
         if self.websockets:
-            # Either the handler or the connection can terminate first,
-            # depending on how the client behaves and the server is
-            # implemented.
+            # The connection handler can terminate before or after the
+            # connection closes. Wait until both are done to avoid leaking
+            # running tasks.
+            # TODO: it would be nicer to wait only for the connection handler
+            # and let the handler wait for the connection to close.
             yield from asyncio.wait(
                 [websocket.handler_task for websocket in self.websockets]
                 + [websocket.close_connection_task for websocket in self.websockets],
                 loop=self.loop,
             )
-        yield from self.server.wait_closed()
+
+        # Tell wait_closed() to return.
+        self.closed_waiter.set_result(None)
+
+    @asyncio.coroutine
+    def wait_closed(self):
+        """
+        Wait until the server is closed and all connections are terminated.
+
+        When :meth:`wait_closed()` returns, all TCP connections are closed and
+        there are no pending tasks left.
+
+        """
+        yield from asyncio.shield(self.closed_waiter)
 
     @property
     def sockets(self):
@@ -694,11 +703,11 @@ class Serve:
     delegates to the WebSocket handler. Once the handler completes, the server
     performs the closing handshake and closes the connection.
 
-    When a server is closed with
-    :meth:`~websockets.server.WebSocketServer.close`, all running WebSocket
-    handlers are canceled. They may intercept :exc:`~asyncio.CancelledError`
-    and perform cleanup actions before re-raising that exception. If a handler
-    started new tasks, it should cancel them as well in that case.
+    When a server is closed with :meth:`~WebSocketServer.close`, it closes all
+    connections with close code 1001 (going away). WebSocket handlers — which
+    are running the coroutine passed in the ``ws_handler`` — will receive a
+    :exc:`~websockets.exceptions.ConnectionClosed` exception on their current
+    or next interaction with the WebSocket connection.
 
     Since there's no useful way to propagate exceptions triggered in handlers,
     they're sent to the ``'websockets.server'`` logger instead. Debugging is

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -121,13 +121,13 @@ class FramingTests(unittest.TestCase):
                     self.decode(encoded)
 
     def test_good_opcode(self):
-        for opcode in list(range(0x00, 0x03)) + list(range(0x08, 0x0b)):
+        for opcode in list(range(0x00, 0x03)) + list(range(0x08, 0x0B)):
             encoded = bytes([0x80 | opcode, 0])
             with self.subTest(encoded=encoded):
                 self.decode(encoded)  # does not raise an exception
 
     def test_bad_opcode(self):
-        for opcode in list(range(0x03, 0x08)) + list(range(0x0b, 0x10)):
+        for opcode in list(range(0x03, 0x08)) + list(range(0x0B, 0x10)):
             encoded = bytes([0x80 | opcode, 0])
             with self.subTest(encoded=encoded):
                 with self.assertRaises(WebSocketProtocolError):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -371,9 +371,10 @@ class CommonTests:
         self.assertTrue(self.protocol.closed)
 
     def test_wait_closed(self):
-        self.assertFalse(self.protocol.wait_closed().done())
+        wait_closed = asyncio_ensure_future(self.protocol.wait_closed())
+        self.assertFalse(wait_closed.done())
         self.close_connection()
-        self.assertTrue(self.protocol.wait_closed().done())
+        self.assertTrue(wait_closed.done())
 
     # Test the recv coroutine.
 


### PR DESCRIPTION
Previously, there were two scenarios where a connection handler on the
server side would receive an unexpected connection termination:

1. When the remote endpoint closed the connection or it dropped for any
   reason: this was signalled with a ConnectionClosed exception when
   interacting with the connection, usually thrown by recv() since most
   connection handlers spend the majority of their time awaiting recv()

2. When the server shut down: this caused the connection handler to be
   cancelled, meaning that a CancelledError exception was injected at
   an arbitrary location.

Now, when the server shuts down, the scenario 1 also applies. This
removes the need to prepare for CancelledError in connection handlers.

A good way to understand this change is to consider that "shutting down
the server" means "shutting down all connections".

Given that WebSocket connections are long-running, I find it sensible
to require connection handlers to detect when the connection they're
managing drops and to terminate.

I expect this to make it easier for users to write connection handlers
that behave correctly when the server shuts down, for two reasons:

- There's only one scenario to implement, which reduces the amount of
  exception handling required. In addition, this avoids the specially
  messy situation where the clean-up process for ConnectionClosed gets
  interrupted by CancelledError.
- Users are much more likely to check what happens when the connection
  drops than when the server shuts down. Making the latter behave like
  the former gives them proper behavior for free.

Another argument for this change is that cancellation wasn't properly
used there. Cancellation should only be used for terminating the
execution of a task that one started when one no longer cares about its
result. Since websockets runs a connection handler provided by the user,
it can't make the decision that whatever code comes next doesn't matter,
especially finalization code.

The counter-argument against this change is that shutdown will be much
slower for a server that reads events from an external source and sends
them over the WebSocket connection. Previously, such a server would
close immediately. Now, unless the connection handler checks for
termination explicitly, it won't notice that the server is closing
until it attempts to send the next event, which could take some time.

Fix #338.

Revert #337 and #392.

Rework #469 for consistency.