### PR TITLE
Handle redirects in client when connecting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Also:
   :meth:`~protocol.WebSocketCommonProtocol.pong` support bytes-like types
   :class:`bytearray` and :class:`memoryview` in addition to :class:`bytes`.
 
+* :func:`~client.connect()` handles redirects from the server during the
+  handshake.
+
 7.0
 ...
 

--- a/src/websockets/compatibility.py
+++ b/src/websockets/compatibility.py
@@ -24,6 +24,11 @@ try:  # pragma: no cover
     UPGRADE_REQUIRED = http.HTTPStatus.UPGRADE_REQUIRED
     INTERNAL_SERVER_ERROR = http.HTTPStatus.INTERNAL_SERVER_ERROR
     SERVICE_UNAVAILABLE = http.HTTPStatus.SERVICE_UNAVAILABLE
+    MOVED_PERMANENTLY = http.HTTPStatus.MOVED_PERMANENTLY
+    FOUND = http.HTTPStatus.FOUND
+    SEE_OTHER = http.HTTPStatus.SEE_OTHER
+    TEMPORARY_REDIRECT = http.HTTPStatus.TEMPORARY_REDIRECT
+    PERMANENT_REDIRECT = http.HTTPStatus.PERMANENT_REDIRECT
 except AttributeError:  # pragma: no cover
     # Python < 3.5
     class SWITCHING_PROTOCOLS:
@@ -57,3 +62,23 @@ except AttributeError:  # pragma: no cover
     class SERVICE_UNAVAILABLE:
         value = 503
         phrase = "Service Unavailable"
+
+    class MOVED_PERMANENTLY:
+        value = 301
+        phrase = "Moved Permanently"
+
+    class FOUND:
+        value = 302
+        phrase = "Found"
+
+    class SEE_OTHER:
+        value = 303
+        phrase = "See Other"
+
+    class TEMPORARY_REDIRECT:
+        value = 307
+        phrase = "Temporary Redirect"
+
+    class PERMANENT_REDIRECT:
+        value = 308
+        phrase = "Permanent Redirect"

--- a/src/websockets/exceptions.py
+++ b/src/websockets/exceptions.py
@@ -43,6 +43,16 @@ class AbortHandshake(InvalidHandshake):
         super().__init__(message)
 
 
+class RedirectHandshake(InvalidHandshake):
+    """
+    Exception raised when a handshake gets redirected.
+
+    """
+
+    def __init__(self, wsuri):
+        self.wsuri = wsuri
+
+
 class InvalidMessage(InvalidHandshake):
     """
     Exception raised when the HTTP message in a handshake request is malformed.

--- a/tests/test_client_server.py
+++ b/tests/test_client_server.py
@@ -82,8 +82,9 @@ def temp_test_server(test, **kwds):
 
 
 @contextlib.contextmanager
-def temp_test_redirecting_server(test, status,
-                                 include_location=True, force_insecure=False):
+def temp_test_redirecting_server(
+    test, status, include_location=True, force_insecure=False
+):
     test.start_redirecting_server(status, include_location, force_insecure)
     try:
         yield
@@ -263,8 +264,9 @@ class ClientServerTests(unittest.TestCase):
         start_server = serve(handler, 'localhost', 0, **kwds)
         self.server = self.loop.run_until_complete(start_server)
 
-    def start_redirecting_server(self, status,
-                                 include_location=True, force_insecure=False):
+    def start_redirecting_server(
+        self, status, include_location=True, force_insecure=False
+    ):
         def _process_request(path, headers):
             server_uri = get_server_uri(self.server, self.secure, path)
             if force_insecure:
@@ -272,11 +274,15 @@ class ClientServerTests(unittest.TestCase):
             headers = {'Location': server_uri} if include_location else []
             return status, headers, b""
 
-        start_server = serve(handler, 'localhost', 0,
-                             compression=None,
-                             ping_interval=None,
-                             process_request=_process_request,
-                             ssl=self.server_context)
+        start_server = serve(
+            handler,
+            'localhost',
+            0,
+            compression=None,
+            ping_interval=None,
+            process_request=_process_request,
+            ssl=self.server_context,
+        )
         self.redirecting_server = self.loop.run_until_complete(start_server)
 
     def start_client(self, resource_name='/', user_info=None, **kwds):
@@ -360,8 +366,9 @@ class ClientServerTests(unittest.TestCase):
 
     @with_server()
     def test_redirect_missing_location(self):
-        with temp_test_redirecting_server(self, http.HTTPStatus.FOUND,
-                                          include_location=False):
+        with temp_test_redirecting_server(
+            self, http.HTTPStatus.FOUND, include_location=False
+        ):
             with self.assertRaises(InvalidMessage):
                 with temp_test_client(self):
                     self.fail('Did not raise')  # pragma: no cover
@@ -1149,8 +1156,9 @@ class SSLClientServerTests(ClientServerTests):
 
     @with_server()
     def test_redirect_insecure(self):
-        with temp_test_redirecting_server(self, http.HTTPStatus.FOUND,
-                                          force_insecure=True):
+        with temp_test_redirecting_server(
+            self, http.HTTPStatus.FOUND, force_insecure=True
+        ):
             with self.assertRaises(InvalidHandshake):
                 with temp_test_client(self):
                     self.fail('Did not raise')  # pragma: no cover

--- a/tests/test_client_server.py
+++ b/tests/test_client_server.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import functools
-import http
 import logging
 import pathlib
 import random
@@ -16,7 +15,16 @@ import urllib.request
 import warnings
 
 from websockets.client import *
-from websockets.compatibility import FORBIDDEN, OK, UNAUTHORIZED
+from websockets.compatibility import (
+    FORBIDDEN,
+    FOUND,
+    MOVED_PERMANENTLY,
+    OK,
+    PERMANENT_REDIRECT,
+    SEE_OTHER,
+    TEMPORARY_REDIRECT,
+    UNAUTHORIZED,
+)
 from websockets.exceptions import (
     ConnectionClosed,
     InvalidHandshake,
@@ -344,11 +352,11 @@ class ClientServerTests(unittest.TestCase):
     @with_server()
     def test_redirect(self):
         redirect_statuses = [
-            http.HTTPStatus.MOVED_PERMANENTLY,
-            http.HTTPStatus.FOUND,
-            http.HTTPStatus.SEE_OTHER,
-            http.HTTPStatus.TEMPORARY_REDIRECT,
-            http.HTTPStatus.PERMANENT_REDIRECT,
+            MOVED_PERMANENTLY,
+            FOUND,
+            SEE_OTHER,
+            TEMPORARY_REDIRECT,
+            PERMANENT_REDIRECT,
         ]
         for status in redirect_statuses:
             with temp_test_redirecting_server(self, status):
@@ -358,7 +366,7 @@ class ClientServerTests(unittest.TestCase):
                     self.assertEqual(reply, "Hello!")
 
     def test_infinite_redirect(self):
-        with temp_test_redirecting_server(self, http.HTTPStatus.FOUND):
+        with temp_test_redirecting_server(self, FOUND):
             self.server = self.redirecting_server
             with self.assertRaises(InvalidHandshake):
                 with temp_test_client(self):
@@ -366,9 +374,7 @@ class ClientServerTests(unittest.TestCase):
 
     @with_server()
     def test_redirect_missing_location(self):
-        with temp_test_redirecting_server(
-            self, http.HTTPStatus.FOUND, include_location=False
-        ):
+        with temp_test_redirecting_server(self, FOUND, include_location=False):
             with self.assertRaises(InvalidMessage):
                 with temp_test_client(self):
                     self.fail('Did not raise')  # pragma: no cover
@@ -1156,9 +1162,7 @@ class SSLClientServerTests(ClientServerTests):
 
     @with_server()
     def test_redirect_insecure(self):
-        with temp_test_redirecting_server(
-            self, http.HTTPStatus.FOUND, force_insecure=True
-        ):
+        with temp_test_redirecting_server(self, FOUND, force_insecure=True):
             with self.assertRaises(InvalidHandshake):
                 with temp_test_client(self):
                     self.fail('Did not raise')  # pragma: no cover


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc6455.html#section-4.2.2 the server may redirect the client during the handshake. This allows the client to handle redirects properly instead of raising an InvalidStatusCode error.