### PR TITLE
Let user override host/port from what is in the uri when connecting

### DIFF
--- a/tests/test_client_server.py
+++ b/tests/test_client_server.py
@@ -385,7 +385,7 @@ class ClientServerTests(unittest.TestCase):
         # override port and fail to connect as a result
         with self.assertRaises(OSError):
             with self.temp_client(port=10000):
-                self.loop.run_until_complete(self.client.send("Hello!"))
+                self.fail("Did not raise")  # pragma: no cover
 
     @with_server()
     def test_explicit_socket(self):

--- a/tests/test_client_server.py
+++ b/tests/test_client_server.py
@@ -375,6 +375,19 @@ class ClientServerTests(unittest.TestCase):
                 self.assertEqual(reply, "Hello!")
 
     @with_server()
+    def test_explicit_host_port(self):
+        # uri contains ip address, overwrite host with "localhost"
+        with self.temp_client(host="localhost"):
+            self.loop.run_until_complete(self.client.send("Hello!"))
+            reply = self.loop.run_until_complete(self.client.recv())
+            self.assertEqual(reply, "Hello!")
+
+        # override port and fail to connect as a result
+        with self.assertRaises(OSError):
+            with self.temp_client(port=10000):
+                self.loop.run_until_complete(self.client.send("Hello!"))
+
+    @with_server()
     def test_explicit_socket(self):
         class TrackedSocket(socket.socket):
             def __init__(self, *args, **kwargs):


### PR DESCRIPTION
In some cases it is useful to connect using an IP address of a server, but you
might still need to keep proper hostname in the url for TLS or for vhosts
routing. For example if you are connecting to `wss://example.com` but via an ssh
tunnel you might want to set `host='127.0.0.1', port=50032` but then supply
`server_hostname='example.com'` for TLS validation.

With this change connection logic detects that alternative `host|port` is
supplied by the user and does not attempt to override it with values from the
uri. If secure connection is requested and host override is used then also set
`server_hostname` to the host name in the uri (unless `server_hostname` was
already supplied by the user)

- closes #540 