### PR TITLE
Call the close() method to terminate websocket connections

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,10 @@ Also:
 
 * Documented how to optimize memory usage.
 
+* Calling :meth:`~server.WebSocketServer.close` properly sets the server
+  :attr:`~protocol.WebSocketCommonProtocol.close_code` to close code 1001
+  (going away).
+
 7.0
 ...
 

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -621,9 +621,10 @@ class WebSocketServer:
 
         # Close open connections. fail_connection() will cancel the transfer
         # data task, which is expected to cause the handler task to terminate.
-        for websocket in self.websockets:
+        # Iterate over a copy since calling close() affects the set
+        for websocket in set(self.websockets):
             if websocket.state is State.OPEN:
-                websocket.fail_connection(1001)
+                await websocket.close(code=1001)
 
         # asyncio.wait doesn't accept an empty first argument.
         if self.websockets:

--- a/tests/test_client_server.py
+++ b/tests/test_client_server.py
@@ -1018,12 +1018,14 @@ class ClientServerTests(unittest.TestCase):
     @with_server()
     def test_server_shuts_down_during_connection_handling(self):
         with self.temp_client():
+            server_protocol = list(self.server.websockets)[0]
             self.server.close()
             with self.assertRaises(ConnectionClosed):
                 self.loop.run_until_complete(self.client.recv())
 
         # Websocket connection terminates with 1001 Going Away.
         self.assertEqual(self.client.close_code, 1001)
+        self.assertEqual(server_protocol.close_code, 1001)
 
     @with_server()
     @unittest.mock.patch("websockets.server.WebSocketServerProtocol.close")


### PR DESCRIPTION
Simple change to fix ticket #541.

Is this all there is to it?