### PR TITLE
Mark package as typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
     packages=packages,
     ext_modules=ext_modules,
     include_package_data=True,
-    zip_safe=True,
+    zip_safe=False,
     python_requires='>=3.6',
     test_loader='unittest:TestLoader',
 )


### PR DESCRIPTION
Just include the `py.typed` file so mypy knows it can use the annotations in the package source when typechecking other code. See [these docs](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages) for details. I'm not sure the change to zip_safe is really needed as I think it only applies to .egg packages, but the docs advised the change, so :man_shrugging: 