### PR TITLE
Change process_request to be a coroutine (again).

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,21 @@ Changelog
 
 .. note::
 
-    **Version 8.0 changes the behavior of the ``max_queue`` parameter.**
+    **Version 8.0 expects** ``process_request`` **to be a coroutine.**
+
+    Previously, it could be a function or a coroutine.
+
+    If you're passing a ``process_request`` argument to :func:`~server.serve`
+    or :class:`~server.WebSocketServerProtocol`, or if you're overriding
+    :meth:`~protocol.WebSocketServerProtocol.process_request` in a subclass,
+    define it with ``async def`` instead of ``def``.
+
+    For backwards compatibility, functions are still supported. However, in
+    some inheritance scenarios, mixing functions and coroutines won't work.
+
+.. note::
+
+    **Version 8.0 changes the behavior of the** ``max_queue`` **parameter.**
 
     If you were setting ``max_queue=0`` to make the queue of incoming messages
     unbounded, change it to ``max_queue=None``.

--- a/example/health_check_server.py
+++ b/example/health_check_server.py
@@ -6,7 +6,7 @@ import asyncio
 import http
 import websockets
 
-def health_check(path, request_headers):
+async def health_check(path, request_headers):
     if path == '/health/':
         return http.HTTPStatus.OK, [], b'OK\n'
 


### PR DESCRIPTION
b64fee8e made it possible to use either a function or a coroutine. It
was part of the 7.0 release.

4f1a14c3 documented this possibility but wasn't released. However, users
may have read the "latest" docs and taken advantage of this.

For this reason, include proper deprecation warnings and preserve
backwards-compatibility (for the foreseeable future).

The deprecation warnings need to be in two locations to account for
passing a process_request argument and for overriding the
process_request method.

Issue #597 shows that `isinstance(..., Awaitable)` is more robust than
`asyncio.iscoroutinefunction(...)` because it also supports functions
returning awaitables.