### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Why shouldn't I use ``websockets``?
   and :rfc:`7692`: Compression Extensions for WebSocket. Its support for HTTP
   is minimal — just enough for a HTTP health check.
 * If you want to use Python 2: ``websockets`` builds upon ``asyncio`` which
-  only works on Python 3. ``websockets`` requires Python ≥ 3.6.
+  only works on Python 3. ``websockets`` requires Python ≥ 3.6.1.
 
 What else?
 ----------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -6,7 +6,7 @@ Getting started
 Requirements
 ------------
 
-``websockets`` requires Python ≥ 3.6.
+``websockets`` requires Python ≥ 3.6.1.
 
 You should use the latest version of Python if possible. If you're using an
 older version, be aware that for each minor version (3.x), only the latest


### PR DESCRIPTION
modify require python version >= 3.6 to >= 3.6.1
cause 3.6.0 does not include Deque in typing. it was added on 3.6.1

Reference: https://docs.python.org/3/library/typing.html