### PR TITLE
Support Python 3.6.0

### DIFF
--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -261,7 +261,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         self.connection_lost_waiter: asyncio.Future[None] = loop.create_future()
 
         # Queue of received messages.
-        self.messages = collections.deque()
+        self.messages: collections.deque = collections.deque()
         self._pop_message_waiter: Optional[asyncio.Future[None]] = None
         self._put_message_waiter: Optional[asyncio.Future[None]] = None
 

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -261,7 +261,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         self.connection_lost_waiter: asyncio.Future[None] = loop.create_future()
 
         # Queue of received messages.
-        self.messages: deque = collections.deque()
+        self.messages = collections.deque()
         self._pop_message_waiter: Optional[asyncio.Future[None]] = None
         self._put_message_waiter: Optional[asyncio.Future[None]] = None
 

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -20,7 +20,6 @@ from typing import (
     AsyncIterable,
     AsyncIterator,
     Awaitable,
-    Deque,
     Dict,
     Iterable,
     List,
@@ -262,7 +261,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
         self.connection_lost_waiter: asyncio.Future[None] = loop.create_future()
 
         # Queue of received messages.
-        self.messages: Deque[Data] = collections.deque()
+        self.messages: deque = collections.deque()
         self._pop_message_waiter: Optional[asyncio.Future[None]] = None
         self._put_message_waiter: Optional[asyncio.Future[None]] = None
 


### PR DESCRIPTION
The `Deque` type from `typing` was added to Python 3.5.4 and Python 3.6.1. It is not available in Python 3.6.0 ([Source](https://docs.python.org/3/library/typing.html#typing.Deque)). By relying on `Deque`, the minimum version of `websockets` has become 3.6.1 while the readme mentions 3.6.0. If this was by choice, close this PR.

Closes #655 

