### PR TITLE
in async_recv(), wait only for futures that really exist

### DIFF
--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -465,7 +465,7 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
                 # If asyncio.wait() is canceled, it doesn't cancel
                 # pop_message_waiter and self.transfer_data_task.
                 await asyncio.wait(
-                    [pop_message_waiter, self.transfer_data_task],
+                    [f for f in [pop_message_waiter, self.transfer_data_task] if f is not None],
                     loop=self.loop,
                     return_when=asyncio.FIRST_COMPLETED,
                 )

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -465,7 +465,11 @@ class WebSocketCommonProtocol(asyncio.StreamReaderProtocol):
                 # If asyncio.wait() is canceled, it doesn't cancel
                 # pop_message_waiter and self.transfer_data_task.
                 await asyncio.wait(
-                    [f for f in [pop_message_waiter, self.transfer_data_task] if f is not None],
+                    [
+                        f
+                        for f in [pop_message_waiter, self.transfer_data_task]
+                        if f is not None
+                    ],
                     loop=self.loop,
                     return_when=asyncio.FIRST_COMPLETED,
                 )


### PR DESCRIPTION
In `WebSocketCommonProtocol().recv()`, `self.transfer_data_task` can be `None` if the connection has closed. In `recv()` there's a call to `asyncio.wait()` with `[self.transfer_data_task]`, and `asyncio.wait()` will proceed to throw an exception when asked to wait for a `None`.

As I understand it, then generally speaking the mechanisms exist that allow `transfer_data_task` to become closed and turn into a `None` – in a situation where `recv()` will run and try to wait on the task's future. This will raise an exception in `ensure_future()` inside `asyncio.tasks.wait()` where `fs` includes `None` (i.e. `transfer_data_task`):
```python
  File "~/.pyenv/versions/3.7.4/lib/python3.7/site-packages/websockets/protocol.py", line 473, in recv
    return_when=asyncio.FIRST_COMPLETED,
  File "~/.pyenv/versions/3.7.4/lib/python3.7/asyncio/tasks.py", line 389, in wait
    fs = {ensure_future(f, loop=loop) for f in set(fs)}
  File "~/.pyenv/versions/3.7.4/lib/python3.7/asyncio/tasks.py", line 389, in <setcomp>
    fs = {ensure_future(f, loop=loop) for f in set(fs)}
  File "~/.pyenv/versions/3.7.4/lib/python3.7/asyncio/tasks.py", line 627, in ensure_future
    raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
TypeError: An asyncio.Future, a coroutine or an awaitable is required
```

A specific thing that will trigger: Starlette's `requires()` authentication decorator will call `websocket.close()` if an authentication scope check fails. This will naturally cause `transfer_data_task` to stop. See here: https://github.com/encode/starlette/blob/7eb0e4e594c7ccc8ec6528cef55b4ccec996b947/starlette/authentication.py#L48

I hope that I'm not mistaken about the mechanisms and that this PR is useful :) Thanks for a great library!