### PR TITLE
Hardcode top-level exports.

### DIFF
--- a/src/websockets/__init__.py
+++ b/src/websockets/__init__.py
@@ -1,6 +1,5 @@
 # This relies on each of the submodules having an __all__ variable.
 
-from . import auth, client, exceptions, protocol, server, typing, uri
 from .auth import *  # noqa
 from .client import *  # noqa
 from .exceptions import *  # noqa
@@ -11,12 +10,46 @@ from .uri import *  # noqa
 from .version import version as __version__  # noqa
 
 
-__all__ = (
-    auth.__all__
-    + client.__all__
-    + exceptions.__all__
-    + protocol.__all__
-    + server.__all__
-    + typing.__all__
-    + uri.__all__
-)
+__all__ = [
+    "AbortHandshake",
+    "basic_auth_protocol_factory",
+    "BasicAuthWebSocketServerProtocol",
+    "connect",
+    "ConnectionClosed",
+    "ConnectionClosedError",
+    "ConnectionClosedOK",
+    "Data",
+    "DuplicateParameter",
+    "ExtensionHeader",
+    "ExtensionParameter",
+    "InvalidHandshake",
+    "InvalidHeader",
+    "InvalidHeaderFormat",
+    "InvalidHeaderValue",
+    "InvalidMessage",
+    "InvalidOrigin",
+    "InvalidParameterName",
+    "InvalidParameterValue",
+    "InvalidState",
+    "InvalidStatusCode",
+    "InvalidUpgrade",
+    "InvalidURI",
+    "NegotiationError",
+    "Origin",
+    "parse_uri",
+    "PayloadTooBig",
+    "ProtocolError",
+    "RedirectHandshake",
+    "SecurityError",
+    "serve",
+    "Subprotocol",
+    "unix_connect",
+    "unix_serve",
+    "WebSocketClientProtocol",
+    "WebSocketCommonProtocol",
+    "WebSocketException",
+    "WebSocketProtocolError",
+    "WebSocketServer",
+    "WebSocketServerProtocol",
+    "WebSocketURI",
+]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,22 @@
+import unittest
+
+import websockets
+
+
+combined_exports = (
+    websockets.auth.__all__
+    + websockets.client.__all__
+    + websockets.exceptions.__all__
+    + websockets.protocol.__all__
+    + websockets.server.__all__
+    + websockets.typing.__all__
+    + websockets.uri.__all__
+)
+
+
+class TestExportsAllSubmodules(unittest.TestCase):
+    def test_top_level_module_reexports_all_submodule_exports(self):
+        self.assertEqual(set(combined_exports), set(websockets.__all__))
+
+    def test_submodule_exports_are_globally_unique(self):
+        self.assertEqual(len(set(combined_exports)), len(combined_exports))


### PR DESCRIPTION
fixes #679 

Also adds a test to make sure no two names are competing with each other in the top-level namespace (e.g. two sub-modules can't export the same name).