### PR TITLE
Fix for Python 3.10: use sys.version_info instead of sys.version

### DIFF
--- a/src/websockets/http.py
+++ b/src/websockets/http.py
@@ -36,7 +36,8 @@ __all__ = [
 MAX_HEADERS = 256
 MAX_LINE = 4096
 
-USER_AGENT = f"Python/{sys.version[:3]} websockets/{websockets_version}"
+PYTHON_VERSION = "{}.{}".format(*sys.version_info)
+USER_AGENT = f"Python/{PYTHON_VERSION} websockets/{websockets_version}"
 
 
 def d(value: bytes) -> str:


### PR DESCRIPTION
When dealing with version numbers, it's generally safer to use the `sys.version_info` tuple that the `sys.version` string.

```pycon
>>> sys.version
'3.7.5 (default, Nov  1 2019, 02:16:32) \n[Clang 11.0.0 (clang-1100.0.33.8)]'
>>> sys.version[:3]
'3.7'
>>> fake_version310_info = '3.10.5 (default, Nov  1 2019, 02:16:32) \n[Clang 11.0.0 (clang-1100.0.33.8)]'
>>> fake_version310_info[:3]
'3.1'
```

When Python 3.10 comes around (probably in [May 2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule)), it will claim to be on Python 3.1!

With the version tuple:

```pycon
>>> "{}.{}".format(3, 7)
'3.7'
>>> "{}.{}".format(3, 10)
'3.10'
```

Found with https://github.com/asottile/flake8-2020.