### PR TITLE
Extended logging information in client/server protocols

### DIFF
--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -325,7 +325,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
 
         """
         # 4.1. The WebSocket Connection is Established.
-        assert self.state is State.CONNECTING
+        assert self.state is State.CONNECTING, "wrong state %r" % self.state
         self.state = State.OPEN
         logger.debug("%s - state = OPEN", self.side)
         # Start the task that receives incoming WebSocket messages.
@@ -812,7 +812,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
             raise self.connection_closed_exc()
 
         # Control may only reach this point in buggy third-party subclasses.
-        assert self.state is State.CONNECTING
+        assert self.state is State.CONNECTING, "wrong state %r" % self.state
         raise InvalidState("WebSocket connection isn't established yet")
 
     async def transfer_data(self) -> None:
@@ -1303,7 +1303,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         They'll never receive a pong once the connection is closed.
 
         """
-        assert self.state is State.CLOSED
+        assert self.state is State.CLOSED, "wrong state %r" % self.state
         exc = self.connection_closed_exc()
 
         for ping in self.pings.values():


### PR DESCRIPTION
While debugging some of our websocket services at work, we found some log messages to be lacking information. We had a hard time keeping track of multiple clients reconnecting and server errors.

First commit displays the state value when asserting we're in a given state while opening connection or pinging.

Then, add a custom `LoggerAdapter` to include IP address of clients, as well as a way to distinguish connections from the same remote host. We chose to display the `id` of a protocol object, but maybe there's something a bit easier to read?

Now that the `LoggerAdapter` is here, we could also move in the showing of `self.side`, but I don't know how to elegantly choose between the various separators used (`x`, `<`, `>`, `!`, `-`).