### PR TITLE
Fix simple typo: severel -> several

### DIFF
--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -134,7 +134,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         client configuration. If no match is found, an exception is raised.
 
         If several variants of the same extension are accepted by the server,
-        it may be configured severel times, which won't make sense in general.
+        it may be configured several times, which won't make sense in general.
         Extensions must implement their own requirements. For this purpose,
         the list of previously accepted extensions is provided.
 

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -369,7 +369,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         server configuration. If no match is found, the extension is ignored.
 
         If several variants of the same extension are proposed by the client,
-        it may be accepted severel times, which won't make sense in general.
+        it may be accepted several times, which won't make sense in general.
         Extensions must implement their own requirements. For this purpose,
         the list of previously accepted extensions is provided.
 


### PR DESCRIPTION
There is a small typo in src/websockets/client.py, src/websockets/server.py.
Should read `several` rather than `severel`.

