### PR TITLE
Use proper stack level in deprecation warnings

### DIFF
--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -397,7 +397,9 @@ class Connect:
         if timeout is None:
             timeout = 10
         else:
-            warnings.warn("rename timeout to close_timeout", DeprecationWarning)
+            warnings.warn(
+                "rename timeout to close_timeout", DeprecationWarning, stacklevel=2
+            )
         # If both are specified, timeout is ignored.
         if close_timeout is None:
             close_timeout = timeout
@@ -406,7 +408,9 @@ class Connect:
         if klass is None:
             klass = WebSocketClientProtocol
         else:
-            warnings.warn("rename klass to create_protocol", DeprecationWarning)
+            warnings.warn(
+                "rename klass to create_protocol", DeprecationWarning, stacklevel=2
+            )
         # If both are specified, klass is ignored.
         if create_protocol is None:
             create_protocol = klass

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -200,7 +200,9 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         if timeout is None:
             timeout = 10
         else:
-            warnings.warn("rename timeout to close_timeout", DeprecationWarning)
+            warnings.warn(
+                "rename timeout to close_timeout", DeprecationWarning, stacklevel=2
+            )
         # If both are specified, timeout is ignored.
         if close_timeout is None:
             close_timeout = timeout
@@ -338,18 +340,22 @@ class WebSocketCommonProtocol(asyncio.Protocol):
     @property
     def host(self) -> Optional[str]:
         alternative = "remote_address" if self.is_client else "local_address"
-        warnings.warn(f"use {alternative}[0] instead of host", DeprecationWarning)
+        warnings.warn(
+            f"use {alternative}[0] instead of host", DeprecationWarning, stacklevel=2
+        )
         return self._host
 
     @property
     def port(self) -> Optional[int]:
         alternative = "remote_address" if self.is_client else "local_address"
-        warnings.warn(f"use {alternative}[1] instead of port", DeprecationWarning)
+        warnings.warn(
+            f"use {alternative}[1] instead of port", DeprecationWarning, stacklevel=2
+        )
         return self._port
 
     @property
     def secure(self) -> Optional[bool]:
-        warnings.warn(f"don't use secure", DeprecationWarning)
+        warnings.warn(f"don't use secure", DeprecationWarning, stacklevel=2)
         return self._secure
 
     # Public API

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -90,7 +90,9 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
     ) -> None:
         # For backwards compatibility with 6.0 or earlier.
         if origins is not None and "" in origins:
-            warnings.warn("use None instead of '' in origins", DeprecationWarning)
+            warnings.warn(
+                "use None instead of '' in origins", DeprecationWarning, stacklevel=2
+            )
             origins = [None if origin == "" else origin for origin in origins]
         self.ws_handler = ws_handler
         self.ws_server = ws_server
@@ -874,7 +876,9 @@ class Serve:
         if timeout is None:
             timeout = 10
         else:
-            warnings.warn("rename timeout to close_timeout", DeprecationWarning)
+            warnings.warn(
+                "rename timeout to close_timeout", DeprecationWarning, stacklevel=2
+            )
         # If both are specified, timeout is ignored.
         if close_timeout is None:
             close_timeout = timeout
@@ -883,7 +887,9 @@ class Serve:
         if klass is None:
             klass = WebSocketServerProtocol
         else:
-            warnings.warn("rename klass to create_protocol", DeprecationWarning)
+            warnings.warn(
+                "rename klass to create_protocol", DeprecationWarning, stacklevel=2
+            )
         # If both are specified, klass is ignored.
         if create_protocol is None:
             create_protocol = klass


### PR DESCRIPTION
Changed the deprecation warnings to use `stacklevel=2` so that the warning will refer to the caller - the warnings are about some code calling constructor with deprecated kwarg or about some code calling deprecated property so it makes more sense to refer to the code that calls them.