### PR TITLE
support request lines of 4107 bytes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ skip_branch_with_pr: true
 
 environment:
 # websockets only works on Python >= 3.6.
-  CIBW_SKIP: cp27-* cp33-* cp34-* cp35-*
+  CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
   CIBW_TEST_COMMAND: python -W default -m unittest
   WEBSOCKETS_TESTS_TIMEOUT_FACTOR: 100
 

--- a/src/websockets/http.py
+++ b/src/websockets/http.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 MAX_HEADERS = 256
-MAX_LINE = 4096
+MAX_LINE = 4107
 
 PYTHON_VERSION = "{}.{}".format(*sys.version_info)
 USER_AGENT = f"Python/{PYTHON_VERSION} websockets/{websockets_version}"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -125,8 +125,8 @@ class HTTPAsyncTests(AsyncioTestCase):
             await read_headers(self.stream)
 
     async def test_line_limit(self):
-        # Header line contains 5 + 4090 + 2 = 4097 bytes.
-        self.stream.feed_data(b"foo: " + b"a" * 4090 + b"\r\n\r\n")
+        # Header line contains 8 + 4097 + 2 = 4107 bytes.
+        self.stream.feed_data(b"cookie: " + b"a" * 4097 + b"x" + b"\r\n\r\n")
         with self.assertRaises(SecurityError):
             await read_headers(self.stream)
 


### PR DESCRIPTION
fix #743

avoid sending a `HTTP 400` response when popular browsers send a request with cookies maxing up the user-agent limit