### PR TITLE
Add contextvar logging

### DIFF
--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -34,11 +34,12 @@ from .http import USER_AGENT, Headers, HeadersLike, read_response
 from .protocol import WebSocketCommonProtocol
 from .typing import ExtensionHeader, Origin, Subprotocol
 from .uri import WebSocketURI, parse_uri
+from .utils import ContextLoggerAdapter
 
 
 __all__ = ["connect", "unix_connect", "WebSocketClientProtocol"]
 
-logger = logging.getLogger(__name__)
+logger = ContextLoggerAdapter(logging.getLogger(__name__))
 
 
 class WebSocketClientProtocol(WebSocketCommonProtocol):

--- a/src/websockets/protocol.py
+++ b/src/websockets/protocol.py
@@ -43,11 +43,12 @@ from .framing import *
 from .handshake import *
 from .http import Headers
 from .typing import Data
+from .utils import ContextLoggerAdapter
 
 
 __all__ = ["WebSocketCommonProtocol"]
 
-logger = logging.getLogger(__name__)
+logger = ContextLoggerAdapter(logging.getLogger(__name__))
 
 
 # A WebSocket connection goes through the following four states, in order:

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -44,11 +44,11 @@ from .headers import build_extension, parse_extension, parse_subprotocol
 from .http import USER_AGENT, Headers, HeadersLike, MultipleValuesError, read_request
 from .protocol import WebSocketCommonProtocol
 from .typing import ExtensionHeader, Origin, Subprotocol
-
+from .utils import ContextLoggerAdapter
 
 __all__ = ["serve", "unix_serve", "WebSocketServerProtocol", "WebSocketServer"]
 
-logger = logging.getLogger(__name__)
+logger = ContextLoggerAdapter(logging.getLogger(__name__))
 
 
 HeadersLikeOrCallable = Union[HeadersLike, Callable[[str, Headers], HeadersLike]]

--- a/src/websockets/utils.py
+++ b/src/websockets/utils.py
@@ -7,7 +7,7 @@ try:
     logging_contextvar = contextvars.ContextVar(
         "websockets_logging_context", default=None
     )
-except ImportError:
+except ModuleNotFoundError:
     logging_contextvar = None
 
 __all__ = ["apply_mask"]


### PR DESCRIPTION
As discussed in #782, this would enable asyncio contextvars logging.

A task would set its context by invoking `websockets.utils.set_logging_contextvar("context...")`.