### PR TITLE
Add NullHandler to root logger

### DIFF
--- a/src/websockets/__init__.py
+++ b/src/websockets/__init__.py
@@ -1,5 +1,7 @@
 # This relies on each of the submodules having an __all__ variable.
 
+import logging
+
 from .auth import *  # noqa
 from .client import *  # noqa
 from .exceptions import *  # noqa
@@ -8,6 +10,9 @@ from .server import *  # noqa
 from .typing import *  # noqa
 from .uri import *  # noqa
 from .version import version as __version__  # noqa
+
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 __all__ = [


### PR DESCRIPTION
This is a small change and makes logging a little more user friendly. Preventing issues like https://github.com/aaugustin/websockets/issues/759 and "no handler could be found" errors. 

This practice (adding a `NullHandler` to a library's root logger) is recommended in [the docs for logging](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library). Examples include requests ([requests/\_\_init__.py](https://github.com/psf/requests/blob/db47b9b/requests/__init__.py#L136)) and urllib3 ([urllib3/\_\_init__.py](https://github.com/urllib3/urllib3/blob/bf15395/src/urllib3/__init__.py#L45)).