### PR TITLE
Add aarch64 wheel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ matrix:
       python: "3.7"
       services:
         - docker
+    - language: python
+      dist: xenial
+      sudo: required
+      python: "3.7"
+      arch: arm64
+      services:
+        - docker
     - os: osx
       osx_image: xcode8.3
 


### PR DESCRIPTION
TravisCI allows creation of arm64 wheels.

Build log: https://travis-ci.com/github/janaknat/websockets/jobs/375133111