### PR TITLE
Support for 1012, 1013 and 1014 close codes

### DIFF
--- a/src/websockets/exceptions.py
+++ b/src/websockets/exceptions.py
@@ -68,6 +68,8 @@ class WebSocketException(Exception):
     """
 
 
+# https://www.iana.org/assignments/websocket/websocket.xhtml
+# see "WebSocket Close Code Number Registry" section for details
 CLOSE_CODES = {
     1000: "OK",
     1001: "going away",
@@ -81,6 +83,9 @@ CLOSE_CODES = {
     1009: "message too big",
     1010: "extension required",
     1011: "unexpected error",
+    1012: "service restart",
+    1013: "service overload",
+    1014: "bad gateway",
     1015: "TLS failure [internal]",
 }
 

--- a/src/websockets/frames.py
+++ b/src/websockets/frames.py
@@ -54,7 +54,8 @@ CTRL_OPCODES = OP_CLOSE, OP_PING, OP_PONG
 
 # Close code that are allowed in a close frame.
 # Using a list optimizes `code in EXTERNAL_CLOSE_CODES`.
-EXTERNAL_CLOSE_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011]
+EXTERNAL_CLOSE_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011,
+                        1012, 1013, 1014]
 
 
 # Consider converting to a dataclass when dropping support for Python < 3.7.

--- a/src/websockets/frames.py
+++ b/src/websockets/frames.py
@@ -53,9 +53,9 @@ DATA_OPCODES = OP_CONT, OP_TEXT, OP_BINARY
 CTRL_OPCODES = OP_CLOSE, OP_PING, OP_PONG
 
 # Close code that are allowed in a close frame.
-# Using a list optimizes `code in EXTERNAL_CLOSE_CODES`.
-EXTERNAL_CLOSE_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011,
-                        1012, 1013, 1014]
+# Using a set optimizes `code in EXTERNAL_CLOSE_CODES`.
+EXTERNAL_CLOSE_CODES = {1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011,
+                        1012, 1013, 1014}
 
 
 # Consider converting to a dataclass when dropping support for Python < 3.7.


### PR DESCRIPTION
Following the motivation of https://github.com/netty/netty/pull/8658 this PR adds 3 additional close codes that would be recognized in the close frames. 
This helps with clarifying reasons for WS closures and avoids misleading `websockets.exceptions.ProtocolError: invalid status code`.

In addition, the second commit replaces a `list` with a `set` for storing close codes, which gives a nice speedup for loookups.