### PR TITLE
Support serve() with existing Unix socket.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,8 @@ fixing regressions shortly after a release.
 
 * Fixed ``Host`` header sent when connecting to an IPv6 address.
 
+* Fixed starting a Unix server listening on an existing socket.
+
 * Aligned maximum cookie size with popular web browsers.
 
 * Ensured cancellation always propagates, even on Python versions where

--- a/tests/extensions/test_permessage_deflate.py
+++ b/tests/extensions/test_permessage_deflate.py
@@ -135,10 +135,12 @@ class PerMessageDeflateTests(unittest.TestCase, ExtensionTestsMixin):
         enc_frame2 = self.extension.encode(frame2)
 
         self.assertEqual(
-            enc_frame1, frame1._replace(rsv1=True, data=b"*IMT\x00\x00\x00\x00\xff\xff")
+            enc_frame1,
+            frame1._replace(rsv1=True, data=b"*IMT\x00\x00\x00\x00\xff\xff"),
         )
         self.assertEqual(
-            enc_frame2, frame2._replace(data=b"*\xc9\xccM\x05\x00")
+            enc_frame2,
+            frame2._replace(data=b"*\xc9\xccM\x05\x00"),
         )
 
         dec_frame1 = self.extension.decode(enc_frame1)


### PR DESCRIPTION
Fix #878.