### PR TITLE
add insecure option for cli

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -207,3 +207,7 @@ One more thing...
 ``websockets`` provides an interactive client::
 
     $ python -m websockets wss://echo.websocket.org/
+
+To see the usage options, run
+
+    $ python -m websockets --help


### PR DESCRIPTION
Fixes #907 

This is only for the `-k` option. I haven't added the `--capath` option yet.
I think that would involve [this](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_default_verify_paths).