### PR TITLE
Python 3.10 compability. fix error: "As of 3.10, the *loop* parameter was removed from Lock()"

### DIFF
--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -230,6 +230,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         if loop is None:
             loop = asyncio.get_event_loop()
         self.loop = loop
+        self.loop_kwarg: Dict[str, Any] = {'loop': self.loop} \
+            if sys.version_info[:2] < (3, 8) else {}
 
         self._host = host
         self._port = port
@@ -246,9 +248,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         self._paused = False
         self._drain_waiter: Optional[asyncio.Future[None]] = None
 
-        self._drain_lock = asyncio.Lock(
-            loop=loop if sys.version_info[:2] < (3, 8) else None
-        )
+        self._drain_lock = asyncio.Lock(**self.loop_kwarg)
 
         # This class implements the data transfer and closing handshake, which
         # are shared between the client-side and the server-side.
@@ -326,9 +326,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
                 #     write(...); yield from drain()
                 # in a loop would never call connection_lost(), so it
                 # would not see an error when the socket is closed.
-                await asyncio.sleep(
-                    0, loop=self.loop if sys.version_info[:2] < (3, 8) else None
-                )
+                await asyncio.sleep(0, **self.loop_kwarg)
         await self._drain_helper()
 
     def connection_open(self) -> None:
@@ -503,8 +501,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
                 # pop_message_waiter and self.transfer_data_task.
                 await asyncio.wait(
                     [pop_message_waiter, self.transfer_data_task],
-                    loop=self.loop if sys.version_info[:2] < (3, 8) else None,
                     return_when=asyncio.FIRST_COMPLETED,
+                    **self.loop_kwarg,
                 )
             finally:
                 self._pop_message_waiter = None
@@ -697,7 +695,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
             await asyncio.wait_for(
                 self.write_close_frame(serialize_close(code, reason)),
                 self.close_timeout,
-                loop=self.loop if sys.version_info[:2] < (3, 8) else None,
+                **self.loop_kwarg,
             )
         except asyncio.TimeoutError:
             # If the close frame cannot be sent because the send buffers
@@ -718,7 +716,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
             await asyncio.wait_for(
                 self.transfer_data_task,
                 self.close_timeout,
-                loop=self.loop if sys.version_info[:2] < (3, 8) else None,
+                **self.loop_kwarg,
             )
         except (asyncio.TimeoutError, asyncio.CancelledError):
             pass
@@ -1140,7 +1138,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
             while True:
                 await asyncio.sleep(
                     self.ping_interval,
-                    loop=self.loop if sys.version_info[:2] < (3, 8) else None,
+                    **self.loop_kwarg,
                 )
 
                 # ping() raises CancelledError if the connection is closed,
@@ -1156,7 +1154,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
                         await asyncio.wait_for(
                             pong_waiter,
                             self.ping_timeout,
-                            loop=self.loop if sys.version_info[:2] < (3, 8) else None,
+                            **self.loop_kwarg,
                         )
                     except asyncio.TimeoutError:
                         logger.debug("%s ! timed out waiting for pong", self.side)
@@ -1256,7 +1254,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
                 await asyncio.wait_for(
                     asyncio.shield(self.connection_lost_waiter),
                     self.close_timeout,
-                    loop=self.loop if sys.version_info[:2] < (3, 8) else None,
+                    **self.loop_kwarg,
                 )
             except asyncio.TimeoutError:
                 pass


### PR DESCRIPTION
Trying to fix #916 