### PR TITLE
Prevent crash of data transfer task

### DIFF
--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -926,14 +926,17 @@ class WebSocketCommonProtocol(asyncio.Protocol):
                     # is empty and parse_close() synthetizes a 1005 close code.
                     await self.write_close_frame(frame.data)
                 except ConnectionClosed:
-                    # It doesn't really matter if the connection was closed
-                    # before we could send back a close frame.
+                    # Connection closed before we could echo the close frame.
                     pass
                 return None
 
             elif frame.opcode == OP_PING:
                 # Answer pings.
-                await self.pong(frame.data)
+                try:
+                    await self.pong(frame.data)
+                except ConnectionClosed:
+                    # Connection closed before we could respond to the ping.
+                    pass
 
             elif frame.opcode == OP_PONG:
                 if frame.data in self.pings:

--- a/tests/legacy/test_protocol.py
+++ b/tests/legacy/test_protocol.py
@@ -877,6 +877,16 @@ class CommonTests:
         self.run_loop_once()
         self.assertOneFrameSent(True, OP_PONG, b"test")
 
+    def test_answer_ping_does_not_crash_if_connection_closed(self):
+        self.make_drain_slow()
+        # Drop the connection right after receiving a ping frame,
+        # which prevents responding wwith a pong frame properly.
+        self.receive_frame(Frame(True, OP_PING, b"test"))
+        self.receive_eof()
+
+        with self.assertNoLogs():
+            self.loop.run_until_complete(self.protocol.close())
+
     def test_ignore_pong(self):
         self.receive_frame(Frame(True, OP_PONG, b"test"))
         self.run_loop_once()


### PR DESCRIPTION
When the read buffer isn't empty, the following scenario is possible:

* TCP connection is closed (one way or another)
* transfer_data is still processing buffered data
* it encounters a ping and attempts to send a pong

transfer_data must never crash, so ignore the error in this case.

Fix #977