### PR TITLE
enforce ascii encoding for headers

### DIFF
--- a/src/websockets/datastructures.py
+++ b/src/websockets/datastructures.py
@@ -94,7 +94,7 @@ class Headers(MutableMapping[str, str]):
 
     def serialize(self) -> bytes:
         # Headers only contain ASCII characters.
-        return str(self).encode()
+        return str(self).encode('ascii')
 
     # Collection methods
 


### PR DESCRIPTION
Even if in the code, it is said that headers contain only ascii characters, the default encoding used is `utf-8`, so I changed it to be `ascii`