### PR TITLE
Redo reference docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,28 @@ release = "9.1"
 
 # -- General configuration ---------------------------------------------------
 
+nitpicky = True
+
+nitpick_ignore = [
+    # topics/design.rst discusses undocumented APIs
+    ("py:meth", "client.WebSocketClientProtocol.handshake"),
+    ("py:meth", "server.WebSocketServerProtocol.handshake"),
+    ("py:attr", "legacy.protocol.WebSocketCommonProtocol.is_client"),
+    ("py:attr", "legacy.protocol.WebSocketCommonProtocol.messages"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.close_connection"),
+    ("py:attr", "legacy.protocol.WebSocketCommonProtocol.close_connection_task"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.keepalive_ping"),
+    ("py:attr", "legacy.protocol.WebSocketCommonProtocol.keepalive_ping_task"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.transfer_data"),
+    ("py:attr", "legacy.protocol.WebSocketCommonProtocol.transfer_data_task"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.connection_open"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.ensure_open"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.fail_connection"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.connection_lost"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.read_message"),
+    ("py:meth", "legacy.protocol.WebSocketCommonProtocol.write_frame"),
+]
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -38,13 +60,22 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
-    "sphinx_autodoc_typehints",
+    "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "sphinxcontrib.spelling",
     "sphinxcontrib_trio",
     "sphinxext.opengraph",
 ]
+
+autodoc_typehints = "description"
+
+autodoc_typehints_description_target = "documented"
+
+# Workaround for https://github.com/sphinx-doc/sphinx/issues/9560
+from sphinx.domains.python import PythonDomain
+assert PythonDomain.object_types['data'].roles == ('data', 'obj')
+PythonDomain.object_types['data'].roles = ('data', 'class', 'obj')
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 

--- a/docs/howto/cheatsheet.rst
+++ b/docs/howto/cheatsheet.rst
@@ -26,27 +26,27 @@ Server
     :meth:`~legacy.protocol.WebSocketCommonProtocol.pong` if you wish but it isn't
     needed in general.
 
-* Create a server with :func:`~legacy.server.serve` which is similar to asyncio's
-  :meth:`~asyncio.AbstractEventLoop.create_server`. You can also use it as an
-  asynchronous context manager.
+* Create a server with :func:`~server.serve` which is similar to asyncio's
+  :meth:`~asyncio.loop.create_server`. You can also use it as an asynchronous
+  context manager.
 
   * The server takes care of establishing connections, then lets the handler
     execute the application logic, and finally closes the connection after the
     handler exits normally or with an exception.
 
   * For advanced customization, you may subclass
-    :class:`~legacy.server.WebSocketServerProtocol` and pass either this subclass or
+    :class:`~server.WebSocketServerProtocol` and pass either this subclass or
     a factory function as the ``create_protocol`` argument.
 
 Client
 ------
 
-* Create a client with :func:`~legacy.client.connect` which is similar to asyncio's
-  :meth:`~asyncio.BaseEventLoop.create_connection`. You can also use it as an
+* Create a client with :func:`~client.connect` which is similar to asyncio's
+  :meth:`~asyncio.loop.create_connection`. You can also use it as an
   asynchronous context manager.
 
   * For advanced customization, you may subclass
-    :class:`~legacy.server.WebSocketClientProtocol` and pass either this subclass or
+    :class:`~client.WebSocketClientProtocol` and pass either this subclass or
     a factory function as the ``create_protocol`` argument.
 
 * Call :meth:`~legacy.protocol.WebSocketCommonProtocol.recv` and
@@ -57,7 +57,7 @@ Client
   :meth:`~legacy.protocol.WebSocketCommonProtocol.pong` if you wish but it isn't
   needed in general.
 
-* If you aren't using :func:`~legacy.client.connect` as a context manager, call
+* If you aren't using :func:`~client.connect` as a context manager, call
   :meth:`~legacy.protocol.WebSocketCommonProtocol.close` to terminate the connection.
 
 .. _debugging:

--- a/docs/howto/django.rst
+++ b/docs/howto/django.rst
@@ -124,7 +124,7 @@ support asynchronous I/O. It would block the event loop if it didn't run in a
 separate thread. :func:`~asyncio.to_thread` is available since Python 3.9. In
 earlier versions, use :meth:`~asyncio.loop.run_in_executor` instead.
 
-Finally, we start a server with :func:`~websockets.serve`.
+Finally, we start a server with :func:`~websockets.server.serve`.
 
 We're ready to test!
 

--- a/docs/howto/extensions.rst
+++ b/docs/howto/extensions.rst
@@ -4,8 +4,10 @@ Writing an extension
 .. currentmodule:: websockets.extensions
 
 During the opening handshake, WebSocket clients and servers negotiate which
-extensions will be used with which parameters. Then each frame is processed by
-extensions before being sent or after being received.
+extensions_ will be used with which parameters. Then each frame is processed
+by extensions before being sent or after being received.
+
+.. _extensions: https://www.rfc-editor.org/rfc/rfc6455.html#section-9
 
 As a consequence, writing an extension requires implementing several classes:
 
@@ -23,11 +25,8 @@ As a consequence, writing an extension requires implementing several classes:
   Extensions are initialized by extension factories, so they don't need to be
   part of the public API of an extension.
 
-websockets provides abstract base classes for extension factories and
-extensions. See the API documentation for details on their methods:
-
-* :class:`ClientExtensionFactory` and :class:`ServerExtensionFactory` for
-  extension factories,
-* :class:`Extension` for extensions.
+websockets provides base classes for extension factories and extensions.
+See :class:`ClientExtensionFactory`, :class:`ServerExtensionFactory`,
+and :class:`Extension` for details.
 
 

--- a/docs/howto/faq.rst
+++ b/docs/howto/faq.rst
@@ -5,7 +5,7 @@ FAQ
 
 .. note::
 
-    Many questions asked in :mod:`websockets`' issue tracker are actually
+    Many questions asked in websockets' issue tracker are actually
     about :mod:`asyncio`. Python's documentation about `developing with
     asyncio`_ is a good complement.
 
@@ -99,13 +99,13 @@ How do I get access HTTP headers, for example cookies?
 ......................................................
 
 To access HTTP headers during the WebSocket handshake, you can override
-:attr:`~legacy.server.WebSocketServerProtocol.process_request`::
+:attr:`~server.WebSocketServerProtocol.process_request`::
 
     async def process_request(self, path, request_headers):
         cookies = request_header["Cookie"]
 
 Once the connection is established, they're available in
-:attr:`~legacy.protocol.WebSocketServerProtocol.request_headers`::
+:attr:`~server.WebSocketServerProtocol.request_headers`::
 
     async def handler(websocket, path):
         cookies = websocket.request_headers["Cookie"]
@@ -123,7 +123,7 @@ How do I set which IP addresses my server listens to?
 
 Look at the ``host`` argument of :meth:`~asyncio.loop.create_server`.
 
-:func:`serve` accepts the same arguments as
+:func:`~server.serve` accepts the same arguments as
 :meth:`~asyncio.loop.create_server`.
 
 How do I close a connection properly?
@@ -143,7 +143,7 @@ Providing a HTTP server is out of scope for websockets. It only aims at
 providing a WebSocket server.
 
 There's limited support for returning HTTP responses with the
-:attr:`~legacy.server.WebSocketServerProtocol.process_request` hook.
+:attr:`~server.WebSocketServerProtocol.process_request` hook.
 
 If you need more, pick a HTTP server and run it separately.
 
@@ -169,7 +169,7 @@ change it to::
 How do I close a connection properly?
 .....................................
 
-The easiest is to use :func:`connect` as a context manager::
+The easiest is to use :func:`~client.connect` as a context manager::
 
     async with connect(...) as websocket:
         ...
@@ -196,7 +196,7 @@ How do I disable TLS/SSL certificate verification?
 
 Look at the ``ssl`` argument of :meth:`~asyncio.loop.create_connection`.
 
-:func:`connect` accepts the same arguments as
+:func:`~client.connect` accepts the same arguments as
 :meth:`~asyncio.loop.create_connection`.
 
 asyncio usage
@@ -449,4 +449,4 @@ I'm having problems with threads
 
 You shouldn't use threads. Use tasks instead.
 
-:func:`~asyncio.AbstractEventLoop.call_soon_threadsafe` may help.
+:meth:`~asyncio.loop.call_soon_threadsafe` may help.

--- a/docs/intro/index.rst
+++ b/docs/intro/index.rst
@@ -82,7 +82,7 @@ This client needs a context because the server uses a self-signed certificate.
 
 A client connecting to a secure WebSocket server with a valid certificate
 (i.e. signed by a CA that your Python installation trusts) can simply pass
-``ssl=True`` to :func:`connect` instead of building a context.
+``ssl=True`` to :func:`~client.connect` instead of building a context.
 
 Browser-based example
 ---------------------

--- a/docs/project/changelog.rst
+++ b/docs/project/changelog.rst
@@ -37,10 +37,10 @@ They may change at any time.
 .. note::
 
     **Version 10.0 enables a timeout of 10 seconds on**
-    :func:`~legacy.client.connect` **by default.**
+    :func:`~client.connect` **by default.**
 
     You can adjust the timeout with the ``open_timeout`` parameter. Set it to
-    ``None`` to disable the timeout entirely.
+    :obj:`None` to disable the timeout entirely.
 
 .. note::
 
@@ -51,7 +51,8 @@ They may change at any time.
 
 .. note::
 
-    **Version 10.0 changes parameters of** ``ConnectionClosed.__init__`` **.**
+    **Version 10.0 changes arguments of**
+    :exc:`~exceptions.ConnectionClosed` **.**
 
     If you raise :exc:`~exceptions.ConnectionClosed` or a subclass — rather
     than catch them when websockets raises them — you must change your code.
@@ -70,27 +71,30 @@ Also:
 * Added :func:`~websockets.broadcast` to send a message to many clients.
 
 * Added support for reconnecting automatically by using
-  :func:`~legacy.client.connect` as an asynchronous iterator.
+  :func:`~client.connect` as an asynchronous iterator.
 
-* Added ``open_timeout`` to :func:`~legacy.client.connect`.
+* Added ``open_timeout`` to :func:`~client.connect`.
 
 * Improved logging.
 
-* Provided additional information in :exc:`ConnectionClosed` exceptions.
+* Provided additional information in :exc:`~exceptions.ConnectionClosed`
+  exceptions.
 
 * Optimized default compression settings to reduce memory usage.
 
 * Made it easier to customize authentication with
   :meth:`~auth.BasicAuthWebSocketServerProtocol.check_credentials`.
 
-* Fixed handling of relative redirects in :func:`~legacy.client.connect`.
+* Fixed handling of relative redirects in :func:`~client.connect`.
+
+* Improved API documentation.
 
 9.1
 ...
 
 *May 27, 2021*
 
-.. note::
+.. caution::
 
     **Version 9.1 fixes a security issue introduced in version 8.0.**
 
@@ -197,7 +201,7 @@ Also:
 *July 31, 2019*
 
 * Restored the ability to pass a socket with the ``sock`` parameter of
-  :func:`~legacy.server.serve`.
+  :func:`~server.serve`.
 
 * Removed an incorrect assertion when a connection drops.
 
@@ -224,9 +228,9 @@ Also:
     Previously, it could be a function or a coroutine.
 
     If you're passing a ``process_request`` argument to
-    :func:`~legacy.server.serve`
-    or :class:`~legacy.server.WebSocketServerProtocol`, or if you're overriding
-    :meth:`~legacy.server.WebSocketServerProtocol.process_request` in a subclass,
+    :func:`~server.serve` or :class:`~server.WebSocketServerProtocol`, or if
+    you're overriding
+    :meth:`~server.WebSocketServerProtocol.process_request` in a subclass,
     define it with ``async def`` instead of ``def``.
 
     For backwards compatibility, functions are still mostly supported, but
@@ -274,15 +278,15 @@ Also:
   :exc:`~exceptions.ConnectionClosed` to tell apart normal connection
   termination from errors.
 
-* Added :func:`~legacy.auth.basic_auth_protocol_factory` to enforce HTTP
+* Added :func:`~auth.basic_auth_protocol_factory` to enforce HTTP
   Basic Auth on the server side.
 
-* :func:`~legacy.client.connect` handles redirects from the server during the
+* :func:`~client.connect` handles redirects from the server during the
   handshake.
 
-* :func:`~legacy.client.connect` supports overriding ``host`` and ``port``.
+* :func:`~client.connect` supports overriding ``host`` and ``port``.
 
-* Added :func:`~legacy.client.unix_connect` for connecting to Unix sockets.
+* Added :func:`~client.unix_connect` for connecting to Unix sockets.
 
 * Improved support for sending fragmented messages by accepting asynchronous
   iterators in :meth:`~legacy.protocol.WebSocketCommonProtocol.send`.
@@ -292,10 +296,10 @@ Also:
   as a workaround, you can remove it.
 
 * Changed :meth:`WebSocketServer.close()
-  <legacy.server.WebSocketServer.close>` to perform a proper closing handshake
+  <server.WebSocketServer.close>` to perform a proper closing handshake
   instead of failing the connection.
 
-* Avoided a crash when a ``extra_headers`` callable returns ``None``.
+* Avoided a crash when a ``extra_headers`` callable returns :obj:`None`.
 
 * Improved error messages when HTTP parsing fails.
 
@@ -327,7 +331,7 @@ Also:
 
     **Version 7.0 changes how a server terminates connections when it's closed
     with** :meth:`WebSocketServer.close()
-    <legacy.server.WebSocketServer.close>` **.**
+    <server.WebSocketServer.close>` **.**
 
     Previously, connections handlers were canceled. Now, connections are
     closed with close code 1001 (going away). From the perspective of the
@@ -345,7 +349,7 @@ Also:
 .. note::
 
     **Version 7.0 renames the** ``timeout`` **argument of**
-    :func:`~legacy.server.serve` **and** :func:`~legacy.client.connect` **to**
+    :func:`~server.serve` **and** :func:`~client.connect` **to**
     ``close_timeout`` **.**
 
     This prevents confusion with ``ping_timeout``.
@@ -375,11 +379,11 @@ Also:
 Also:
 
 * Added ``process_request`` and ``select_subprotocol`` arguments to
-  :func:`~legacy.server.serve` and
-  :class:`~legacy.server.WebSocketServerProtocol` to customize
-  :meth:`~legacy.server.WebSocketServerProtocol.process_request` and
-  :meth:`~legacy.server.WebSocketServerProtocol.select_subprotocol` without
-  subclassing :class:`~legacy.server.WebSocketServerProtocol`.
+  :func:`~server.serve` and
+  :class:`~server.WebSocketServerProtocol` to customize
+  :meth:`~server.WebSocketServerProtocol.process_request` and
+  :meth:`~server.WebSocketServerProtocol.select_subprotocol` without
+  subclassing :class:`~server.WebSocketServerProtocol`.
 
 * Added support for sending fragmented messages.
 
@@ -389,7 +393,7 @@ Also:
 * Added an interactive client: ``python -m websockets <uri>``.
 
 * Changed the ``origins`` argument to represent the lack of an origin with
-  ``None`` rather than ``''``.
+  :obj:`None` rather than ``''``.
 
 * Fixed a data loss bug in
   :meth:`~legacy.protocol.WebSocketCommonProtocol.recv`:
@@ -409,7 +413,7 @@ Also:
     **Version 6.0 introduces the** :class:`~datastructures.Headers` **class
     for managing HTTP headers and changes several public APIs:**
 
-    * :meth:`~legacy.server.WebSocketServerProtocol.process_request` now
+    * :meth:`~server.WebSocketServerProtocol.process_request` now
       receives a :class:`~datastructures.Headers` instead of a
       ``http.client.HTTPMessage`` in the ``request_headers`` argument.
 
@@ -445,14 +449,14 @@ Also:
 *May 24, 2018*
 
 * Fixed a regression in 5.0 that broke some invocations of
-  :func:`~legacy.server.serve` and :func:`~legacy.client.connect`.
+  :func:`~server.serve` and :func:`~client.connect`.
 
 5.0
 ...
 
 *May 22, 2018*
 
-.. note::
+.. caution::
 
     **Version 5.0 fixes a security issue introduced in version 4.0.**
 
@@ -465,14 +469,14 @@ Also:
 .. note::
 
     **Version 5.0 adds a** ``user_info`` **field to the return value of**
-    :func:`~uri.parse_uri` **and** :class:`~uri.WebSocketURI` **.**
+    ``parse_uri`` **and** ``WebSocketURI`` **.**
 
-    If you're unpacking :class:`~uri.WebSocketURI` into four variables, adjust
-    your code to account for that fifth field.
+    If you're unpacking ``WebSocketURI`` into four variables, adjust your code
+    to account for that fifth field.
 
 Also:
 
-* :func:`~legacy.client.connect` performs HTTP Basic Auth when the URI contains
+* :func:`~client.connect` performs HTTP Basic Auth when the URI contains
   credentials.
 
 * Iterating on incoming messages no longer raises an exception when the
@@ -481,7 +485,7 @@ Also:
 * A plain HTTP request now receives a 426 Upgrade Required response and
   doesn't log a stack trace.
 
-* :func:`~legacy.server.unix_serve` can be used as an asynchronous context
+* :func:`~server.unix_serve` can be used as an asynchronous context
   manager on Python ≥ 3.5.1.
 
 * Added the :attr:`~legacy.protocol.WebSocketCommonProtocol.closed` property
@@ -536,7 +540,7 @@ Also:
     Compression should improve performance but it increases RAM and CPU use.
 
     If you want to disable compression, add ``compression=None`` when calling
-    :func:`~legacy.server.serve` or :func:`~legacy.client.connect`.
+    :func:`~server.serve` or :func:`~client.connect`.
 
 .. note::
 
@@ -549,10 +553,10 @@ Also:
 * :class:`~legacy.protocol.WebSocketCommonProtocol` instances can be used as
   asynchronous iterators on Python ≥ 3.6. They yield incoming messages.
 
-* Added :func:`~legacy.server.unix_serve` for listening on Unix sockets.
+* Added :func:`~server.unix_serve` for listening on Unix sockets.
 
-* Added the :attr:`~legacy.server.WebSocketServer.sockets` attribute to the
-  return value of :func:`~legacy.server.serve`.
+* Added the :attr:`~server.WebSocketServer.sockets` attribute to the
+  return value of :func:`~server.serve`.
 
 * Reorganized and extended documentation.
 
@@ -572,15 +576,15 @@ Also:
 
 *August 20, 2017*
 
-* Renamed :func:`~legacy.server.serve` and :func:`~legacy.client.connect`'s
+* Renamed :func:`~server.serve` and :func:`~client.connect`'s
   ``klass`` argument to ``create_protocol`` to reflect that it can also be a
   callable. For backwards compatibility, ``klass`` is still supported.
 
-* :func:`~legacy.server.serve` can be used as an asynchronous context manager
+* :func:`~server.serve` can be used as an asynchronous context manager
   on Python ≥ 3.5.1.
 
 * Added support for customizing handling of incoming connections with
-  :meth:`~legacy.server.WebSocketServerProtocol.process_request`.
+  :meth:`~server.WebSocketServerProtocol.process_request`.
 
 * Made read and write buffer sizes configurable.
 
@@ -588,10 +592,10 @@ Also:
 
 * Added an optional C extension to speed up low-level operations.
 
-* An invalid response status code during :func:`~legacy.client.connect` now
+* An invalid response status code during :func:`~client.connect` now
   raises :class:`~exceptions.InvalidStatusCode`.
 
-* Providing a ``sock`` argument to :func:`~legacy.client.connect` no longer
+* Providing a ``sock`` argument to :func:`~client.connect` no longer
   crashes.
 
 3.3
@@ -611,7 +615,7 @@ Also:
 *August 17, 2016*
 
 * Added ``timeout``, ``max_size``, and ``max_queue`` arguments to
-  :func:`~legacy.client.connect` and :func:`~legacy.server.serve`.
+  :func:`~client.connect` and :func:`~server.serve`.
 
 * Made server shutdown more robust.
 
@@ -637,8 +641,8 @@ Also:
     **If you're upgrading from 2.x or earlier, please read this carefully.**
 
     :meth:`~legacy.protocol.WebSocketCommonProtocol.recv` used to return
-    ``None`` when the connection was closed. This required checking the return
-    value of every call::
+    :obj:`None` when the connection was closed. This required checking the
+    return value of every call::
 
         message = await websocket.recv()
         if message is None:
@@ -655,14 +659,14 @@ Also:
 
     In order to avoid stranding projects built upon an earlier version, the
     previous behavior can be restored by passing ``legacy_recv=True`` to
-    :func:`~legacy.server.serve`, :func:`~legacy.client.connect`,
-    :class:`~legacy.server.WebSocketServerProtocol`, or
-    :class:`~legacy.client.WebSocketClientProtocol`. ``legacy_recv`` isn't
+    :func:`~server.serve`, :func:`~client.connect`,
+    :class:`~server.WebSocketServerProtocol`, or
+    :class:`~client.WebSocketClientProtocol`. ``legacy_recv`` isn't
     documented in their signatures but isn't scheduled for deprecation either.
 
 Also:
 
-* :func:`~legacy.client.connect` can be used as an asynchronous context
+* :func:`~client.connect` can be used as an asynchronous context
   manager on Python ≥ 3.5.1.
 
 * Updated documentation with ``await`` and ``async`` syntax from Python 3.5.
@@ -732,8 +736,8 @@ Also:
 
 * Added support for subprotocols.
 
-* Added ``loop`` argument to :func:`~legacy.client.connect` and
-  :func:`~legacy.server.serve`.
+* Added ``loop`` argument to :func:`~client.connect` and
+  :func:`~server.serve`.
 
 2.3
 ...

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -6,67 +6,55 @@ Client
     Opening a connection
     --------------------
 
-    .. autofunction:: connect(uri, *, create_protocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, compression='deflate', origin=None, extensions=None, subprotocols=None, extra_headers=None, logger=None, **kwds)
+    .. autofunction:: connect(uri, *, create_protocol=None, logger=None, compression="deflate", origin=None, extensions=None, subprotocols=None, extra_headers=None, open_timeout=10, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, **kwds)
         :async:
 
-    .. autofunction:: unix_connect(path, uri="ws://localhost/", *, create_protocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, compression='deflate', origin=None, extensions=None, subprotocols=None, extra_headers=None, logger=None, **kwds)
+    .. autofunction:: unix_connect(path, uri="ws://localhost/", *, create_protocol=None, logger=None, compression="deflate", origin=None, extensions=None, subprotocols=None, extra_headers=None, open_timeout=10, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, **kwds)
         :async:
 
     Using a connection
     ------------------
 
-    .. autoclass:: WebSocketClientProtocol(*, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, origin=None, extensions=None, subprotocols=None, extra_headers=None, logger=None)
-
-        .. attribute:: id
-
-            UUID for the connection.
-
-            Useful for identifying connections in logs.
-
-        .. autoattribute:: local_address
-
-        .. autoattribute:: remote_address
-
-        .. autoattribute:: open
-
-        .. autoattribute:: closed
-
-        .. attribute:: path
-
-            Path of the HTTP request.
-
-            Available once the connection is open.
-
-        .. attribute:: request_headers
-
-            HTTP request headers as a :class:`~websockets.http.Headers` instance.
-
-            Available once the connection is open.
-
-        .. attribute:: response_headers
-
-            HTTP response headers as a :class:`~websockets.http.Headers` instance.
-
-            Available once the connection is open.
-
-        .. attribute:: subprotocol
-
-            Subprotocol, if one was negotiated.
-
-            Available once the connection is open.
-
-        .. autoattribute:: close_code
-
-        .. autoattribute:: close_reason
+    .. autoclass:: WebSocketClientProtocol(*, logger=None, origin=None, extensions=None, subprotocols=None, extra_headers=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16)
 
         .. automethod:: recv
 
         .. automethod:: send
 
+        .. automethod:: close
+
+        .. automethod:: wait_closed
+
         .. automethod:: ping
 
         .. automethod:: pong
 
-        .. automethod:: close
+        WebSocket connection objects also provide these attributes:
 
-        .. automethod:: wait_closed
+        .. autoattribute:: id
+
+        .. autoproperty:: local_address
+
+        .. autoproperty:: remote_address
+
+        .. autoproperty:: open
+
+        .. autoproperty:: closed
+
+        The following attributes are available after the opening handshake,
+        once the WebSocket connection is open:
+
+        .. autoattribute:: path
+
+        .. autoattribute:: request_headers
+
+        .. autoattribute:: response_headers
+
+        .. autoattribute:: subprotocol
+
+        The following attributes are available after the closing handshake,
+        once the WebSocket connection is closed:
+
+        .. autoproperty:: close_code
+
+        .. autoproperty:: close_reason

--- a/docs/reference/common.rst
+++ b/docs/reference/common.rst
@@ -1,0 +1,51 @@
+Both sides
+==========
+
+.. automodule:: websockets.legacy.protocol
+
+    Using a connection
+    ------------------
+
+    .. autoclass:: WebSocketCommonProtocol(*, logger=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16)
+
+        .. automethod:: recv
+
+        .. automethod:: send
+
+        .. automethod:: close
+
+        .. automethod:: wait_closed
+
+        .. automethod:: ping
+
+        .. automethod:: pong
+
+        WebSocket connection objects also provide these attributes:
+
+        .. autoattribute:: id
+
+        .. autoproperty:: local_address
+
+        .. autoproperty:: remote_address
+
+        .. autoproperty:: open
+
+        .. autoproperty:: closed
+
+        The following attributes are available after the opening handshake,
+        once the WebSocket connection is open:
+
+        .. autoattribute:: path
+
+        .. autoattribute:: request_headers
+
+        .. autoattribute:: response_headers
+
+        .. autoattribute:: subprotocol
+
+        The following attributes are available after the closing handshake,
+        once the WebSocket connection is closed:
+
+        .. autoproperty:: close_code
+
+        .. autoproperty:: close_reason

--- a/docs/reference/exceptions.rst
+++ b/docs/reference/exceptions.rst
@@ -1,0 +1,6 @@
+Exceptions
+==========
+
+.. automodule:: websockets.exceptions
+    :members:
+

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -6,7 +6,7 @@ Extensions
 The WebSocket protocol supports extensions_.
 
 At the time of writing, there's only one `registered extension`_ with a public
-specification, WebSocket Per-Message Deflate, specified in :rfc:`7692`.
+specification, WebSocket Per-Message Deflate.
 
 .. _extensions: https://www.rfc-editor.org/rfc/rfc6455.html#section-9
 .. _registered extension: https://www.iana.org/assignments/websocket/websocket.xhtml#extension-name
@@ -16,21 +16,45 @@ Per-Message Deflate
 
 .. automodule:: websockets.extensions.permessage_deflate
 
+    :mod:`websockets.extensions.permessage_deflate` implements WebSocket
+    Per-Message Deflate.
+
+    This extension is specified in :rfc:`7692`.
+
+    Refer to the :doc:`topic guide on compression <../topics/compression>` to
+    learn more about tuning compression settings.
+
     .. autoclass:: ClientPerMessageDeflateFactory
 
     .. autoclass:: ServerPerMessageDeflateFactory
 
-Abstract classes
-----------------
+Base classes
+------------
 
 .. automodule:: websockets.extensions
 
+    :mod:`websockets.extensions` defines base classes for implementing
+     extensions.
+
+    Refer to the :doc:`how-to guide on extensions <../howto/extensions>` to
+    learn more about writing an extension.
+
     .. autoclass:: Extension
-        :members:
+
+        .. autoattribute:: name
+
+        .. automethod:: decode
+
+        .. automethod:: encode
 
     .. autoclass:: ClientExtensionFactory
-        :members:
+
+        .. autoattribute:: name
+
+        .. automethod:: get_request_params
+
+        .. automethod:: process_response_params
 
     .. autoclass:: ServerExtensionFactory
-        :members:
 
+        .. automethod:: process_request_params

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,24 +1,27 @@
 API reference
 =============
 
-websockets provides complete client and server implementations, as shown in
+.. currentmodule:: websockets
+
+websockets provides client and server implementations, as shown in
 the :doc:`getting started guide <../intro/index>`.
 
 The process for opening and closing a WebSocket connection depends on which
 side you're implementing.
 
-* On the client side, connecting to a server with :class:`~websockets.connect`
+* On the client side, connecting to a server with :func:`~client.connect`
   yields a connection object that provides methods for interacting with the
   connection. Your code can open a connection, then send or receive messages.
 
-  If you use :class:`~websockets.connect` as an asynchronous context manager,
+  If you use :func:`~client.connect` as an asynchronous context manager,
   then websockets closes the connection on exit. If not, then your code is
   responsible for closing the connection.
 
-* On the server side, :class:`~websockets.serve` starts listening for client
-  connections and yields an server object that supports closing the server.
+* On the server side, :func:`~server.serve` starts listening for client
+  connections and yields an server object that you can use to shut down
+  the server.
 
-  Then, when clients connects, the server initializes a connection object and
+  Then, when a client connects, the server initializes a connection object and
   passes it to a handler coroutine, which is where your code can send or
   receive messages. This pattern is called `inversion of control`_. It's
   common in frameworks implementing servers.
@@ -29,28 +32,35 @@ side you're implementing.
 .. _inversion of control: https://en.wikipedia.org/wiki/Inversion_of_control
 
 Once the connection is open, the WebSocket protocol is symmetrical, except for
-low-level details that websockets manages under the hood. The same methods are
-available on client connections created with :class:`~websockets.connect` and
-on server connections passed to the connection handler in the arguments.
+low-level details that websockets manages under the hood. The same methods
+are available on client connections created with :func:`~client.connect` and
+on server connections received in argument by the connection handler
+of :func:`~server.serve`.
 
-At this point, websockets provides the same API — and uses the same code — for
-client and server connections. For convenience, common methods are documented
-both in the client API and server API.
+Since websockets provides the same API — and uses the same code — for client
+and server connections, common methods are documented in a "Both sides" page.
 
 .. toctree::
    :titlesonly:
 
    client
    server
-   extensions
+   common
    utilities
+   exceptions
+   types
+   extensions
    limitations
 
-All public APIs can be imported from the :mod:`websockets` package, unless
-noted otherwise. This convenience feature is incompatible with static code
-analysis tools such as mypy_, though.
+Public API documented in the API reference are subject to the
+:ref:`backwards-compatibility policy <backwards-compatibility policy>`.
+
+Anything that isn't listed in the API reference is a private API. There's no
+guarantees of behavior or backwards-compatibility for private APIs.
+
+For convenience, many public APIs can be imported from the ``websockets``
+package. This feature is incompatible with static code analysis tools such as
+mypy_, though. If you're using such tools, use the full import path.
 
 .. _mypy: https://github.com/python/mypy
 
-Anything that isn't listed in this API documentation is a private API. There's
-no guarantees of behavior or backwards-compatibility for private APIs.

--- a/docs/reference/limitations.rst
+++ b/docs/reference/limitations.rst
@@ -1,12 +1,14 @@
 Limitations
 ===========
 
+.. currentmodule:: websockets
+
 Client
 ------
 
 The client doesn't attempt to guarantee that there is no more than one
 connection to a given IP address in a CONNECTING state. This behavior is
-`mandated by RFC 6455`_. However, :func:`~websockets.connect()` isn't the
+`mandated by RFC 6455`_. However, :func:`~client.connect()` isn't the
 right layer for enforcing this constraint. It's the caller's responsibility.
 
 .. _mandated by RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1

--- a/docs/reference/server.rst
+++ b/docs/reference/server.rst
@@ -6,10 +6,10 @@ Server
     Starting a server
     -----------------
 
-    .. autofunction:: serve(ws_handler, host=None, port=None, *, create_protocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, compression='deflate', origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, logger=None, **kwds)
+    .. autofunction:: serve(ws_handler, host=None, port=None, *, create_protocol=None, logger=None, compression="deflate", origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, **kwds)
         :async:
 
-    .. autofunction:: unix_serve(ws_handler, path, *, create_protocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, compression='deflate', origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, logger=None, **kwds)
+    .. autofunction:: unix_serve(ws_handler, path=None, *, create_protocol=None, logger=None, compression="deflate", origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, **kwds)
         :async:
 
     Stopping a server
@@ -17,92 +17,80 @@ Server
 
     .. autoclass:: WebSocketServer
 
-        .. autoattribute:: sockets
-
         .. automethod:: close
+
         .. automethod:: wait_closed
+
+        .. autoattribute:: sockets
 
     Using a connection
     ------------------
 
-    .. autoclass:: WebSocketServerProtocol(ws_handler, ws_server, *, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16, origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, logger=None)
-
-        .. attribute:: id
-
-            UUID for the connection.
-
-            Useful for identifying connections in logs.
-
-        .. autoattribute:: local_address
-
-        .. autoattribute:: remote_address
-
-        .. autoattribute:: open
-
-        .. autoattribute:: closed
-
-        .. attribute:: path
-
-            Path of the HTTP request.
-
-            Available once the connection is open.
-
-        .. attribute:: request_headers
-
-            HTTP request headers as a :class:`~websockets.http.Headers` instance.
-
-            Available once the connection is open.
-
-        .. attribute:: response_headers
-
-            HTTP response headers as a :class:`~websockets.http.Headers` instance.
-
-            Available once the connection is open.
-
-        .. attribute:: subprotocol
-
-            Subprotocol, if one was negotiated.
-
-            Available once the connection is open.
-
-        .. autoattribute:: close_code
-
-        .. autoattribute:: close_reason
-
-        .. automethod:: process_request
-
-        .. automethod:: select_subprotocol
+    .. autoclass:: WebSocketServerProtocol(ws_handler, ws_server, *, logger=None, origins=None, extensions=None, subprotocols=None, extra_headers=None, process_request=None, select_subprotocol=None, ping_interval=20, ping_timeout=20, close_timeout=10, max_size=2 ** 20, max_queue=2 ** 5, read_limit=2 ** 16, write_limit=2 ** 16)
 
         .. automethod:: recv
 
         .. automethod:: send
 
+        .. automethod:: close
+
+        .. automethod:: wait_closed
+
         .. automethod:: ping
 
         .. automethod:: pong
 
-        .. automethod:: close
+        You can customize the opening handshake in a subclass by overriding these methods:
 
-        .. automethod:: wait_closed
+        .. automethod:: process_request
+
+        .. automethod:: select_subprotocol
+
+        WebSocket connection objects also provide these attributes:
+
+        .. autoattribute:: id
+
+        .. autoproperty:: local_address
+
+        .. autoproperty:: remote_address
+
+        .. autoproperty:: open
+
+        .. autoproperty:: closed
+
+        The following attributes are available after the opening handshake,
+        once the WebSocket connection is open:
+
+        .. autoattribute:: path
+
+        .. autoattribute:: request_headers
+
+        .. autoattribute:: response_headers
+
+        .. autoattribute:: subprotocol
+
+        The following attributes are available after the closing handshake,
+        once the WebSocket connection is closed:
+
+        .. autoproperty:: close_code
+
+        .. autoproperty:: close_reason
+
 
 Basic authentication
 --------------------
 
 .. automodule:: websockets.auth
 
+    websockets supports HTTP Basic Authentication according to
+    :rfc:`7235` and :rfc:`7617`.
+
     .. autofunction:: basic_auth_protocol_factory
 
     .. autoclass:: BasicAuthWebSocketServerProtocol
 
-        .. attribute:: realm
+        .. autoattribute:: realm
 
-            Scope of protection.
-
-            If provided, it should contain only ASCII characters because the
-            encoding of non-ASCII characters is undefined.
-
-        .. attribute:: username
-
-            Username of the authenticated user.
+        .. autoattribute:: username
 
         .. automethod:: check_credentials

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -1,0 +1,20 @@
+Types
+=====
+
+.. autodata:: websockets.datastructures.HeadersLike
+
+.. automodule:: websockets.typing
+
+    .. autodata:: Data
+
+    .. autodata:: LoggerLike
+
+    .. autodata:: Origin
+
+    .. autodata:: Subprotocol
+
+    .. autodata:: ExtensionName
+
+    .. autodata:: ExtensionParameter
+
+

--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -6,36 +6,32 @@ Broadcast
 
 .. autofunction:: websockets.broadcast
 
-Data structures
----------------
+WebSocket events
+----------------
+
+.. automodule:: websockets.frames
+
+    .. autoclass:: Frame
+
+    .. autoclass:: Opcode
+
+    .. autoclass:: Close
+
+HTTP events
+-----------
+
+.. automodule:: websockets.http11
+
+    .. autoclass:: Request
+
+    .. autoclass:: Response
 
 .. automodule:: websockets.datastructures
 
     .. autoclass:: Headers
 
-    .. autodata:: HeadersLike
+        .. automethod:: get_all
+
+        .. automethod:: raw_items
 
     .. autoexception:: MultipleValuesError
-
-Exceptions
-----------
-
-.. automodule:: websockets.exceptions
-    :members:
-
-Types
------
-
-.. automodule:: websockets.typing
-
-    .. autodata:: Data
-
-    .. autodata:: LoggerLike
-
-    .. autodata:: Origin
-
-    .. autodata:: Subprotocol
-
-    .. autodata:: ExtensionName
-
-    .. autodata:: ExtensionParameter

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 furo
 sphinx
 sphinx-autobuild
-sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-inline-tabs
 sphinxcontrib-spelling

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -35,6 +35,7 @@ linkerd
 liveness
 lookups
 MiB
+mypy
 nginx
 permessage
 pid
@@ -59,6 +60,7 @@ tox
 unregister
 uple
 uvicorn
+uvloop
 virtualenv
 WebSocket
 websocket

--- a/docs/topics/broadcast.rst
+++ b/docs/topics/broadcast.rst
@@ -1,13 +1,13 @@
 Broadcasting messages
 =====================
 
-.. currentmodule: websockets
+.. currentmodule:: websockets
 
 
 .. note::
 
     If you just want to send a message to all connected clients, use
-    :func:`~websockets.broadcast`.
+    :func:`broadcast`.
 
     If you want to learn about its design in depth, continue reading this
     document.
@@ -16,7 +16,7 @@ WebSocket servers often send the same message to all connected clients or to a
 subset of clients for which the message is relevant.
 
 Let's explore options for broadcasting a message, explain the design
-of :func:`~websockets.broadcast`, and discuss alternatives.
+of :func:`broadcast`, and discuss alternatives.
 
 For each option, we'll provide a connection handler called ``handler()`` and a
 function or coroutine called ``broadcast()`` that sends a message to all
@@ -122,7 +122,7 @@ connections before the write buffer has time to fill up.
 
 Don't set extreme ``write_limit``, ``ping_interval``, and ``ping_timeout``
 values to ensure that this condition holds. Set reasonable values and use the
-built-in :func:`~websockets.broadcast` function instead.
+built-in :func:`broadcast` function instead.
 
 The concurrent way
 ------------------
@@ -207,11 +207,11 @@ If a client gets too far behind, eventually it reaches the limit defined by
 ``ping_timeout`` and websockets terminates the connection. You can read the
 discussion of :doc:`keepalive and timeouts <./timeouts>` for details.
 
-How :func:`~websockets.broadcast` works
----------------------------------------
+How :func:`broadcast` works
+---------------------------
 
-The built-in :func:`~websockets.broadcast` function is similar to the naive
-way. The main difference is that it doesn't apply backpressure.
+The built-in :func:`broadcast` function is similar to the naive way. The main
+difference is that it doesn't apply backpressure.
 
 This provides the best performance by avoiding the overhead of scheduling and
 running one task per client.
@@ -321,9 +321,9 @@ the asynchronous iterator returned by ``subscribe()``.
 Performance considerations
 --------------------------
 
-The built-in :func:`~websockets.broadcast` function sends all messages without
-yielding control to the event loop. So does the naive way when the network
-and clients are fast and reliable.
+The built-in :func:`broadcast` function sends all messages without yielding
+control to the event loop. So does the naive way when the network and clients
+are fast and reliable.
 
 For each client, a WebSocket frame is prepared and sent to the network. This
 is the minimum amount of work required to broadcast a message.
@@ -343,7 +343,7 @@ However, this isn't possible in general for two reasons:
 
 All other patterns discussed above yield control to the event loop once per
 client because messages are sent by different tasks. This makes them slower
-than the built-in :func:`~websockets.broadcast` function.
+than the built-in :func:`broadcast` function.
 
 There is no major difference between the performance of per-message queues and
 publish–subscribe.

--- a/docs/topics/compression.rst
+++ b/docs/topics/compression.rst
@@ -1,6 +1,8 @@
 Compression
 ===========
 
+.. currentmodule:: websockets.extensions.permessage_deflate
+
 Most WebSocket servers exchange JSON messages because they're convenient to
 parse and serialize in a browser. These messages contain text data and tend to
 be repetitive.
@@ -29,9 +31,8 @@ If you want to disable compression, set ``compression=None``::
     websockets.serve(..., compression=None)
 
 If you want to customize compression settings, you can enable the Per-Message
-Deflate extension explicitly with
-:class:`~permessage_deflate.ClientPerMessageDeflateFactory` or
-:class:`~permessage_deflate.ServerPerMessageDeflateFactory`::
+Deflate extension explicitly with :class:`ClientPerMessageDeflateFactory` or
+:class:`ServerPerMessageDeflateFactory`::
 
     import websockets
     from websockets.extensions import permessage_deflate

--- a/docs/topics/deployment.rst
+++ b/docs/topics/deployment.rst
@@ -78,7 +78,7 @@ Option 2 almost always combines with option 3.
 How do I start a process?
 .........................
 
-Run a Python program that invokes :func:`~serve`. That's it.
+Run a Python program that invokes :func:`~server.serve`. That's it.
 
 Don't run an ASGI server such as Uvicorn, Hypercorn, or Daphne. They're
 alternatives to websockets, not complements.

--- a/docs/topics/memory.rst
+++ b/docs/topics/memory.rst
@@ -1,6 +1,8 @@
 Memory usage
 ============
 
+.. currentmodule:: websockets
+
 In most cases, memory usage of a WebSocket server is proportional to the
 number of open connections. When a server handles thousands of connections,
 memory usage can become a bottleneck.
@@ -17,8 +19,8 @@ Baseline
 Compression settings are the main factor affecting the baseline amount of
 memory used by each connection.
 
-Read to the topic guide on :doc:`../topics/compression` to learn more about
-tuning compression settings.
+Refer to the :doc:`topic guide on compression <../topics/compression>` to
+learn more about tuning compression settings.
 
 Buffers
 -------
@@ -29,7 +31,7 @@ Under high load, if a server receives more messages than it can process,
 bufferbloat can result in excessive memory usage.
 
 By default websockets has generous limits. It is strongly recommended to adapt
-them to your application. When you call :func:`~legacy.server.serve`:
+them to your application. When you call :func:`~server.serve`:
 
 - Set ``max_size`` (default: 1 MiB, UTF-8 encoded) to the maximum size of
   messages your application generates.
@@ -40,4 +42,4 @@ them to your application. When you call :func:`~legacy.server.serve`:
 Furthermore, you can lower ``read_limit`` and ``write_limit`` (default:
 64 KiB) to reduce the size of buffers for incoming and outgoing data.
 
-The design document provides :ref:`more details about buffers<buffers>`.
+The design document provides :ref:`more details about buffers <buffers>`.

--- a/docs/topics/timeouts.rst
+++ b/docs/topics/timeouts.rst
@@ -1,6 +1,8 @@
 Timeouts
 ========
 
+.. currentmodule:: websockets
+
 Since the WebSocket protocol is intended for real-time communications over
 long-lived connections, it is desirable to ensure that connections don't
 break, and if they do, to report the problem quickly.
@@ -13,15 +15,18 @@ As a consequence, proxies may terminate WebSocket connections prematurely,
 when no message was exchanged in 30 seconds.
 
 In order to avoid this problem, websockets implements a keepalive mechanism
-based on WebSocket Ping and Pong frames. Ping and Pong are designed for this
+based on WebSocket Ping_ and Pong_ frames. Ping and Pong are designed for this
 purpose.
+
+.. _Ping: https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.2
+.. _Pong: https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.3
 
 By default, websockets waits 20 seconds, then sends a Ping frame, and expects
 to receive the corresponding Pong frame within 20 seconds. Else, it considers
 the connection broken and closes it.
 
 Timings are configurable with the ``ping_interval`` and ``ping_timeout``
-arguments of :func:`~websockets.connect` and :func:`~websockets.serve`.
+arguments of :func:`~client.connect` and :func:`~server.serve`.
 
 While WebSocket runs on top of TCP, websockets doesn't rely on TCP keepalive
 because it's disabled by default and, if enabled, the default interval is no

--- a/src/websockets/__init__.py
+++ b/src/websockets/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .imports import lazy_import
 from .version import version as __version__  # noqa
 

--- a/src/websockets/__main__.py
+++ b/src/websockets/__main__.py
@@ -183,7 +183,7 @@ def main() -> None:
 
     # Due to zealous removal of the loop parameter in the Queue constructor,
     # we need a factory coroutine to run in the freshly created event loop.
-    async def queue_factory() -> "asyncio.Queue[str]":
+    async def queue_factory() -> asyncio.Queue[str]:
         return asyncio.Queue()
 
     # Create a queue of user inputs. There's no need to limit its size.

--- a/src/websockets/auth.py
+++ b/src/websockets/auth.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 # See #940 for why lazy_import isn't used here for backwards compatibility.
 from .legacy.auth import *  # noqa

--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -68,7 +68,7 @@ class ClientConnection(Connection):
 
     def connect(self) -> Request:  # noqa: F811
         """
-        Create a WebSocket handshake request event to send to the server.
+        Create a WebSocket handshake request event to open a connection.
 
         """
         headers = Headers()
@@ -107,12 +107,13 @@ class ClientConnection(Connection):
 
     def process_response(self, response: Response) -> None:
         """
-        Check a handshake response received from the server.
+        Check a handshake response.
 
-        :param response: response
-        :param key: comes from :func:`build_request`
-        :raises ~websockets.exceptions.InvalidHandshake: if the handshake response
-            is invalid
+        Args:
+            request: WebSocket handshake response received from the server.
+
+        Raises:
+            InvalidHandshake: if the handshake response is invalid.
 
         """
 
@@ -162,11 +163,6 @@ class ClientConnection(Connection):
 
         Check that each extension is supported, as well as its parameters.
 
-        Return the list of accepted extensions.
-
-        Raise :exc:`~websockets.exceptions.InvalidHandshake` to abort the
-        connection.
-
         :rfc:`6455` leaves the rules up to the specification of each
         extension.
 
@@ -181,6 +177,15 @@ class ClientConnection(Connection):
 
         Other requirements, for example related to mandatory extensions or the
         order of extensions, may be implemented by overriding this method.
+
+        Args:
+            headers: WebSocket handshake response headers.
+
+        Returns:
+            List[Extension]: List of accepted extensions.
+
+        Raises:
+            InvalidHandshake: to abort the handshake.
 
         """
         accepted_extensions: List[Extension] = []
@@ -232,9 +237,13 @@ class ClientConnection(Connection):
         """
         Handle the Sec-WebSocket-Protocol HTTP response header.
 
-        Check that it contains exactly one supported subprotocol.
+        If provided, check that it contains exactly one supported subprotocol.
 
-        Return the selected subprotocol.
+        Args:
+            headers: WebSocket handshake response headers.
+
+        Returns:
+           Optional[Subprotocol]: Subprotocol, if one was selected.
 
         """
         subprotocol: Optional[Subprotocol] = None
@@ -263,7 +272,10 @@ class ClientConnection(Connection):
 
     def send_request(self, request: Request) -> None:
         """
-        Send a WebSocket handshake request to the server.
+        Send a handshake request to the server.
+
+        Args:
+            request: WebSocket handshake request event to send.
 
         """
         if self.debug:

--- a/src/websockets/connection.py
+++ b/src/websockets/connection.py
@@ -212,7 +212,8 @@ class Connection:
         - You must call :meth:`data_to_send` and send this data.
         - You should call :meth:`events_received` and process these events.
 
-        :raises EOFError: if :meth:`receive_eof` was called before
+        Raises:
+            EOFError: if :meth:`receive_eof` was called before.
 
         """
         self.reader.feed_data(data)
@@ -228,7 +229,8 @@ class Connection:
         - You aren't exepcted to call :meth:`events_received` as it won't
           return any new events.
 
-        :raises EOFError: if :meth:`receive_eof` was called before
+        Raises:
+            EOFError: if :meth:`receive_eof` was called before.
 
         """
         self.reader.feed_eof()
@@ -367,8 +369,8 @@ class Connection:
         Tell whether the TCP connection is expected to close soon.
 
         Call this method immediately after calling any of the ``receive_*()``
-        or ``fail_*()``  methods and, if it returns ``True``, schedule closing
-        the TCP connection after a short timeout.
+        or ``fail_*()``  methods and, if it returns :obj:`True`, schedule
+        closing the TCP connection after a short timeout.
 
         """
         # We already got a TCP Close if and only if the state is CLOSED.

--- a/src/websockets/datastructures.py
+++ b/src/websockets/datastructures.py
@@ -1,8 +1,3 @@
-"""
-:mod:`websockets.datastructures` defines a class for manipulating HTTP headers.
-
-"""
-
 from __future__ import annotations
 
 from typing import (
@@ -141,7 +136,7 @@ class Headers(MutableMapping[str, str]):
 
     def update(self, *args: HeadersLike, **kwargs: str) -> None:
         """
-        Update from a Headers instance and/or keyword arguments.
+        Update from a :class:`Headers` instance and/or keyword arguments.
 
         """
         args = tuple(
@@ -155,7 +150,8 @@ class Headers(MutableMapping[str, str]):
         """
         Return the (possibly empty) list of all values for a header.
 
-        :param key: header name
+        Args:
+            key: header name.
 
         """
         return self._dict.get(key.lower(), [])

--- a/src/websockets/exceptions.py
+++ b/src/websockets/exceptions.py
@@ -67,7 +67,7 @@ __all__ = [
 
 class WebSocketException(Exception):
     """
-    Base class for all exceptions defined by :mod:`websockets`.
+    Base class for all exceptions defined by websockets.
 
     """
 
@@ -76,17 +76,14 @@ class ConnectionClosed(WebSocketException):
     """
     Raised when trying to interact with a closed connection.
 
-    If a close frame was received, its code and reason are available in the
-    ``rcvd.code`` and ``rcvd.reason`` attributes. Else, the ``rcvd``
-    attribute is ``None``.
-
-    Likewise, if a close frame was sent, its code and reason are available in
-    the ``sent.code`` and ``sent.reason`` attributes. Else, the ``sent``
-    attribute is ``None``.
-
-    If close frames were received and sent, the ``rcvd_then_sent`` attribute
-    tells in which order this happened, from the perspective of this side of
-    the connection.
+    Attributes:
+        rcvd (Optional[Close]): if a close frame was received, its code and
+            reason are available in ``rcvd.code`` and ``rcvd.reason``.
+        sent (Optional[Close]): if a close frame was sent, its code and reason
+            are available in ``sent.code`` and ``sent.reason``.
+        rcvd_then_sent (Optional[bool]): if close frames were received and
+            sent, this attribute tells in which order this happened, from the
+            perspective of this side of the connection.
 
     """
 
@@ -249,9 +246,6 @@ class InvalidStatusCode(InvalidHandshake):
     """
     Raised when a handshake response status code is invalid.
 
-    The integer status code is available in the ``status_code`` attribute and
-    HTTP headers in the ``headers`` attribute.
-
     """
 
     def __init__(self, status_code: int, headers: datastructures.Headers) -> None:
@@ -320,8 +314,13 @@ class AbortHandshake(InvalidHandshake):
 
     This exception is an implementation detail.
 
-    The public API is :meth:`~legacy.server.WebSocketServerProtocol.process_request`.
+    The public API
+    is :meth:`~websockets.server.WebSocketServerProtocol.process_request`.
 
+    Attributes:
+        status (~http.HTTPStatus): HTTP status code.
+        headers (Headers): HTTP response headers.
+        body (bytes): HTTP response body.
     """
 
     def __init__(

--- a/src/websockets/extensions/base.py
+++ b/src/websockets/extensions/base.py
@@ -1,13 +1,3 @@
-"""
-:mod:`websockets.extensions.base` defines abstract classes for implementing
-extensions.
-
-See `section 9 of RFC 6455`_.
-
-.. _section 9 of RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-9
-
-"""
-
 from __future__ import annotations
 
 from typing import List, Optional, Sequence, Tuple
@@ -21,16 +11,12 @@ __all__ = ["Extension", "ClientExtensionFactory", "ServerExtensionFactory"]
 
 class Extension:
     """
-    Abstract class for extensions.
+    Base class for extensions.
 
     """
 
-    @property
-    def name(self) -> ExtensionName:
-        """
-        Extension identifier.
-
-        """
+    name: ExtensionName
+    """Extension identifier."""
 
     def decode(
         self,
@@ -41,8 +27,15 @@ class Extension:
         """
         Decode an incoming frame.
 
-        :param frame: incoming frame
-        :param max_size: maximum payload size in bytes
+        Args:
+            frame (Frame): incoming frame.
+            max_size: maximum payload size in bytes.
+
+        Returns:
+            Frame: Decoded frame.
+
+        Raises:
+            PayloadTooBig: if decoding the payload exceeds ``max_size``.
 
         """
 
@@ -50,29 +43,30 @@ class Extension:
         """
         Encode an outgoing frame.
 
-        :param frame: outgoing frame
+        Args:
+            frame (Frame): outgoing frame.
+
+        Returns:
+            Frame: Encoded frame.
 
         """
 
 
 class ClientExtensionFactory:
     """
-    Abstract class for client-side extension factories.
+    Base class for client-side extension factories.
 
     """
 
-    @property
-    def name(self) -> ExtensionName:
-        """
-        Extension identifier.
-
-        """
+    name: ExtensionName
+    """Extension identifier."""
 
     def get_request_params(self) -> List[ExtensionParameter]:
         """
-        Build request parameters.
+        Build parameters to send to the server for this extension.
 
-        Return a list of ``(name, value)`` pairs.
+        Returns:
+            List[ExtensionParameter]: Parameters to send to the server.
 
         """
 
@@ -82,28 +76,31 @@ class ClientExtensionFactory:
         accepted_extensions: Sequence[Extension],
     ) -> Extension:
         """
-        Process response parameters received from the server.
+        Process parameters received from the server.
 
-        :param params: list of ``(name, value)`` pairs.
-        :param accepted_extensions: list of previously accepted extensions.
-        :raises ~websockets.exceptions.NegotiationError: if parameters aren't
-            acceptable
+        Args:
+            params (Sequence[ExtensionParameter]): parameters received from
+                the server for this extension.
+            accepted_extensions (Sequence[Extension]): list of previously
+                accepted extensions.
+
+        Returns:
+            Extension: An extension instance.
+
+        Raises:
+            NegotiationError: if parameters aren't acceptable.
 
         """
 
 
 class ServerExtensionFactory:
     """
-    Abstract class for server-side extension factories.
+    Base class for server-side extension factories.
 
     """
 
-    @property
-    def name(self) -> ExtensionName:
-        """
-        Extension identifier.
-
-        """
+    name: ExtensionName
+    """Extension identifier."""
 
     def process_request_params(
         self,
@@ -111,16 +108,21 @@ class ServerExtensionFactory:
         accepted_extensions: Sequence[Extension],
     ) -> Tuple[List[ExtensionParameter], Extension]:
         """
-        Process request parameters received from the client.
+        Process parameters received from the client.
 
-        To accept the offer, return a 2-uple containing:
+        Args:
+            params (Sequence[ExtensionParameter]): parameters received from
+                the client for this extension.
+            accepted_extensions (Sequence[Extension]): list of previously
+                accepted extensions.
 
-        - response parameters: a list of ``(name, value)`` pairs
-        - an extension: an instance of a subclass of :class:`Extension`
+        Returns:
+            Tuple[List[ExtensionParameter], Extension]: To accept the offer,
+            parameters to send to the client for this extension and an
+            extension instance.
 
-        :param params: list of ``(name, value)`` pairs.
-        :param accepted_extensions: list of previously accepted extensions.
-        :raises ~websockets.exceptions.NegotiationError: to reject the offer,
-            if parameters aren't acceptable
+        Raises:
+            NegotiationError: to reject the offer, if parameters received from
+                the client aren't acceptable.
 
         """

--- a/src/websockets/extensions/permessage_deflate.py
+++ b/src/websockets/extensions/permessage_deflate.py
@@ -1,9 +1,3 @@
-"""
-:mod:`websockets.extensions.permessage_deflate` implements the Compression
-Extensions for WebSocket as specified in :rfc:`7692`.
-
-"""
-
 from __future__ import annotations
 
 import dataclasses
@@ -204,8 +198,8 @@ def _extract_parameters(
     """
     Extract compression parameters from a list of ``(name, value)`` pairs.
 
-    If ``is_server`` is ``True``, ``client_max_window_bits`` may be provided
-    without a value. This is only allow in handshake requests.
+    If ``is_server`` is :obj:`True`, ``client_max_window_bits`` may be
+    provided without a value. This is only allowed in handshake requests.
 
     """
     server_no_context_takeover: bool = False
@@ -264,18 +258,23 @@ class ClientPerMessageDeflateFactory(ClientExtensionFactory):
     """
     Client-side extension factory for the Per-Message Deflate extension.
 
-    Parameters behave as described in `section 7.1 of RFC 7692`_. Set them to
-    ``True`` to include them in the negotiation offer without a value or to an
-    integer value to include them with this value.
+    Parameters behave as described in `section 7.1 of RFC 7692`_.
 
     .. _section 7.1 of RFC 7692: https://www.rfc-editor.org/rfc/rfc7692.html#section-7.1
 
-    :param server_no_context_takeover: defaults to ``False``
-    :param client_no_context_takeover: defaults to ``False``
-    :param server_max_window_bits: optional, defaults to ``None``
-    :param client_max_window_bits: optional, defaults to ``None``
-    :param compress_settings: optional, keyword arguments for
-        :func:`zlib.compressobj`, excluding ``wbits``
+    Set them to :obj:`True` to include them in the negotiation offer without a
+    value or to an integer value to include them with this value.
+
+    Args:
+        server_no_context_takeover: prevent server from using context takeover.
+        client_no_context_takeover: prevent client from using context takeover.
+        server_max_window_bits: maximum size of the server's LZ77 sliding window
+            in bits, between 8 and 15.
+        client_max_window_bits: maximum size of the client's LZ77 sliding window
+            in bits, between 8 and 15, or :obj:`True` to indicate support without
+            setting a limit.
+        compress_settings: additional keyword arguments for :func:`zlib.compressobj`,
+            excluding ``wbits``.
 
     """
 
@@ -440,7 +439,6 @@ def enable_client_permessage_deflate(
     If the extension is already present, perhaps with non-default settings,
     the configuration isn't changed.
 
-
     """
     if extensions is None:
         extensions = []
@@ -462,18 +460,23 @@ class ServerPerMessageDeflateFactory(ServerExtensionFactory):
     """
     Server-side extension factory for the Per-Message Deflate extension.
 
-    Parameters behave as described in `section 7.1 of RFC 7692`_. Set them to
-    ``True`` to include them in the negotiation offer without a value or to an
-    integer value to include them with this value.
+    Parameters behave as described in `section 7.1 of RFC 7692`_.
 
     .. _section 7.1 of RFC 7692: https://www.rfc-editor.org/rfc/rfc7692.html#section-7.1
 
-    :param server_no_context_takeover: defaults to ``False``
-    :param client_no_context_takeover: defaults to ``False``
-    :param server_max_window_bits: optional, defaults to ``None``
-    :param client_max_window_bits: optional, defaults to ``None``
-    :param compress_settings: optional, keyword arguments for
-        :func:`zlib.compressobj`, excluding ``wbits``
+    Set them to :obj:`True` to include them in the negotiation offer without a
+    value or to an integer value to include them with this value.
+
+    Args:
+        server_no_context_takeover: prevent server from using context takeover.
+        client_no_context_takeover: prevent client from using context takeover.
+        server_max_window_bits: maximum size of the server's LZ77 sliding window
+            in bits, between 8 and 15.
+        client_max_window_bits: maximum size of the client's LZ77 sliding window
+            in bits, between 8 and 15, or :obj:`True` to indicate support without
+            setting a limit.
+        compress_settings: additional keyword arguments for :func:`zlib.compressobj`,
+            excluding ``wbits``.
 
     """
 

--- a/src/websockets/frames.py
+++ b/src/websockets/frames.py
@@ -1,8 +1,3 @@
-"""
-Parse and serialize WebSocket frames.
-
-"""
-
 from __future__ import annotations
 
 import dataclasses
@@ -104,15 +99,16 @@ class Frame:
     """
     WebSocket frame.
 
-    :param int opcode: opcode
-    :param bytes data: payload data
-    :param bool fin: FIN bit
-    :param bool rsv1: RSV1 bit
-    :param bool rsv2: RSV2 bit
-    :param bool rsv3: RSV3 bit
+    Args:
+        opcode: opcode.
+        data: payload data.
+        fin: FIN bit.
+        rsv1: RSV1 bit.
+        rsv2: RSV2 bit.
+        rsv3: RSV3 bit.
 
     Only these fields are needed. The MASK bit, payload length and masking-key
-    are handled on the fly by :meth:`parse` and :meth:`serialize`.
+    are handled on the fly when parsing and serializing frames.
 
     """
 
@@ -176,22 +172,23 @@ class Frame:
         mask: bool,
         max_size: Optional[int] = None,
         extensions: Optional[Sequence[extensions.Extension]] = None,
-    ) -> Generator[None, None, "Frame"]:
+    ) -> Generator[None, None, Frame]:
         """
-        Read a WebSocket frame.
+        Parse a WebSocket frame.
 
-        :param read_exact: generator-based coroutine that reads the requested
-            number of bytes or raises an exception if there isn't enough data
-        :param mask: whether the frame should be masked i.e. whether the read
-            happens on the server side
-        :param max_size: maximum payload size in bytes
-        :param extensions: list of classes with a ``decode()`` method that
-            transforms the frame and return a new frame; extensions are applied
-            in reverse order
-        :raises ~websockets.exceptions.PayloadTooBig: if the frame exceeds
-            ``max_size``
-        :raises ~websockets.exceptions.ProtocolError: if the frame
-            contains incorrect values
+        This is a generator-based coroutine.
+
+        Args:
+            read_exact: generator-based coroutine that reads the requested
+                bytes or raises an exception if there isn't enough data.
+            mask: whether the frame should be masked i.e. whether the read
+                happens on the server side.
+            max_size: maximum payload size in bytes.
+            extensions: list of extensions, applied in reverse order.
+
+        Raises:
+            PayloadTooBig: if the frame's payload size exceeds ``max_size``.
+            ProtocolError: if the frame contains incorrect values.
 
         """
         # Read the header.
@@ -249,16 +246,15 @@ class Frame:
         extensions: Optional[Sequence[extensions.Extension]] = None,
     ) -> bytes:
         """
-        Write a WebSocket frame.
+        Serialize a WebSocket frame.
 
-        :param frame: frame to write
-        :param mask: whether the frame should be masked i.e. whether the write
-            happens on the client side
-        :param extensions: list of classes with an ``encode()`` method that
-            transform the frame and return a new frame; extensions are applied
-            in order
-        :raises ~websockets.exceptions.ProtocolError: if the frame
-            contains incorrect values
+        Args:
+            mask: whether the frame should be masked i.e. whether the write
+                happens on the client side.
+            extensions: list of extensions, applied in order.
+
+        Raises:
+            ProtocolError: if the frame contains incorrect values.
 
         """
         self.check()
@@ -306,8 +302,8 @@ class Frame:
         """
         Check that reserved bits and opcode have acceptable values.
 
-        :raises ~websockets.exceptions.ProtocolError: if a reserved
-            bit or the opcode is invalid
+        Raises:
+            ProtocolError: if a reserved bit or the opcode is invalid.
 
         """
         if self.rsv1 or self.rsv2 or self.rsv3:
@@ -332,7 +328,8 @@ def prepare_data(data: Data) -> Tuple[int, bytes]:
     If ``data`` is a bytes-like object, return ``OP_BINARY`` and a bytes-like
     object.
 
-    :raises TypeError: if ``data`` doesn't have a supported type
+    Raises:
+        TypeError: if ``data`` doesn't have a supported type.
 
     """
     if isinstance(data, str):
@@ -354,7 +351,8 @@ def prepare_ctrl(data: Data) -> bytes:
 
     If ``data`` is a bytes-like object, return a :class:`bytes` object.
 
-    :raises TypeError: if ``data`` doesn't have a supported type
+    Raises:
+        TypeError: if ``data`` doesn't have a supported type.
 
     """
     if isinstance(data, str):
@@ -398,8 +396,12 @@ class Close:
         """
         Parse the payload of a close frame.
 
-        :raises ~websockets.exceptions.ProtocolError: if data is ill-formed
-        :raises UnicodeDecodeError: if the reason isn't valid UTF-8
+        Args:
+            data: payload of the close frame.
+
+        Raises:
+            ProtocolError: if data is ill-formed.
+            UnicodeDecodeError: if the reason isn't valid UTF-8.
 
         """
         if len(data) >= 2:
@@ -415,9 +417,7 @@ class Close:
 
     def serialize(self) -> bytes:
         """
-        Serialize the payload for a close frame.
-
-        This is the reverse of :meth:`parse`.
+        Serialize the payload of a close frame.
 
         """
         self.check()
@@ -427,8 +427,8 @@ class Close:
         """
         Check that the close code has a valid value for a close frame.
 
-        :raises ~websockets.exceptions.ProtocolError: if the close code
-            is invalid
+        Raises:
+            ProtocolError: if the close code is invalid.
 
         """
         if not (self.code in EXTERNAL_CLOSE_CODES or 3000 <= self.code < 5000):

--- a/src/websockets/headers.py
+++ b/src/websockets/headers.py
@@ -1,9 +1,3 @@
-"""
-:mod:`websockets.headers` provides parsers and serializers for HTTP headers
-used in WebSocket handshake messages.
-
-"""
-
 from __future__ import annotations
 
 import base64
@@ -48,7 +42,7 @@ def peek_ahead(header: str, pos: int) -> Optional[str]:
     """
     Return the next character from ``header`` at the given position.
 
-    Return ``None`` at the end of ``header``.
+    Return :obj:`None` at the end of ``header``.
 
     We never need to peek more than one character ahead.
 
@@ -83,7 +77,8 @@ def parse_token(header: str, pos: int, header_name: str) -> Tuple[str, int]:
 
     Return the token value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     match = _token_re.match(header, pos)
@@ -106,7 +101,8 @@ def parse_quoted_string(header: str, pos: int, header_name: str) -> Tuple[str, i
 
     Return the unquoted value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     match = _quoted_string_re.match(header, pos)
@@ -158,7 +154,8 @@ def parse_list(
 
     Return a list of items.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     # Per https://www.rfc-editor.org/rfc/rfc7230.html#section-7, "a recipient
@@ -211,7 +208,8 @@ def parse_connection_option(
 
     Return the protocol value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     item, pos = parse_token(header, pos, header_name)
@@ -224,8 +222,11 @@ def parse_connection(header: str) -> List[ConnectionOption]:
 
     Return a list of HTTP connection options.
 
-    :param header: value of the ``Connection`` header
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Args
+        header: value of the ``Connection`` header.
+
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     return parse_list(parse_connection_option, header, 0, "Connection")
@@ -244,7 +245,8 @@ def parse_upgrade_protocol(
 
     Return the protocol value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     match = _protocol_re.match(header, pos)
@@ -261,8 +263,11 @@ def parse_upgrade(header: str) -> List[UpgradeProtocol]:
 
     Return a list of HTTP protocols.
 
-    :param header: value of the ``Upgrade`` header
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Args:
+        header: value of the ``Upgrade`` header.
+
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     return parse_list(parse_upgrade_protocol, header, 0, "Upgrade")
@@ -276,7 +281,8 @@ def parse_extension_item_param(
 
     Return a ``(name, value)`` pair and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     # Extract parameter name.
@@ -312,7 +318,8 @@ def parse_extension_item(
     Return an ``(extension name, parameters)`` pair, where ``parameters`` is a
     list of ``(name, value)`` pairs, and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     # Extract extension name.
@@ -344,9 +351,10 @@ def parse_extension(header: str) -> List[ExtensionHeader]:
             ...
         ]
 
-    Parameter values are ``None`` when no value is provided.
+    Parameter values are :obj:`None` when no value is provided.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     return parse_list(parse_extension_item, header, 0, "Sec-WebSocket-Extensions")
@@ -397,7 +405,8 @@ def parse_subprotocol_item(
 
     Return the subprotocol value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     item, pos = parse_token(header, pos, header_name)
@@ -410,7 +419,8 @@ def parse_subprotocol(header: str) -> List[Subprotocol]:
 
     Return a list of WebSocket subprotocols.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     return parse_list(parse_subprotocol_item, header, 0, "Sec-WebSocket-Protocol")
@@ -450,7 +460,8 @@ def build_www_authenticate_basic(realm: str) -> str:
     """
     Build a ``WWW-Authenticate`` header for HTTP Basic Auth.
 
-    :param realm: authentication realm
+    Args:
+        realm: identifier of the protection space.
 
     """
     # https://www.rfc-editor.org/rfc/rfc7617.html#section-2
@@ -468,7 +479,8 @@ def parse_token68(header: str, pos: int, header_name: str) -> Tuple[str, int]:
 
     Return the token value and the new position.
 
-    :raises ~websockets.exceptions.InvalidHeaderFormat: on invalid inputs.
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
 
     """
     match = _token68_re.match(header, pos)
@@ -494,9 +506,12 @@ def parse_authorization_basic(header: str) -> Tuple[str, str]:
 
     Return a ``(username, password)`` tuple.
 
-    :param header: value of the ``Authorization`` header
-    :raises InvalidHeaderFormat: on invalid inputs
-    :raises InvalidHeaderValue: on unsupported inputs
+    Args:
+        header: value of the ``Authorization`` header.
+
+    Raises:
+        InvalidHeaderFormat: on invalid inputs.
+        InvalidHeaderValue: on unsupported inputs.
 
     """
     # https://www.rfc-editor.org/rfc/rfc7235.html#section-2.1

--- a/src/websockets/imports.py
+++ b/src/websockets/imports.py
@@ -9,15 +9,15 @@ __all__ = ["lazy_import"]
 
 def import_name(name: str, source: str, namespace: Dict[str, Any]) -> Any:
     """
-    Import <name> from <source> in <namespace>.
+    Import ``name`` from ``source`` in ``namespace``.
 
-    There are two cases:
+    There are two use cases:
 
-    - <name> is an object defined in <source>
-    - <name> is a submodule of source
+    - ``name`` is an object defined in ``source``;
+    - ``name`` is a submodule of ``source``.
 
-    Neither __import__ nor importlib.import_module does exactly this.
-    __import__ is closer to the intended behavior.
+    Neither :func:`__import__` nor :func:`~importlib.import_module` does
+    exactly this. :func:`__import__` is closer to the intended behavior.
 
     """
     level = 0
@@ -49,7 +49,7 @@ def lazy_import(
             }
         )
 
-    This function defines __getattr__ and __dir__ per PEP 562.
+    This function defines ``__getattr__`` and ``__dir__`` per :pep:`562`.
 
     """
     if aliases is None:

--- a/src/websockets/legacy/framing.py
+++ b/src/websockets/legacy/framing.py
@@ -1,15 +1,3 @@
-"""
-:mod:`websockets.legacy.framing` reads and writes WebSocket frames.
-
-It deals with a single frame at a time. Anything that depends on the sequence
-of frames is implemented in :mod:`websockets.legacy.protocol`.
-
-See `section 5 of RFC 6455`_.
-
-.. _section 5 of RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-5
-
-"""
-
 from __future__ import annotations
 
 import dataclasses
@@ -60,22 +48,21 @@ class Frame(NamedTuple):
         mask: bool,
         max_size: Optional[int] = None,
         extensions: Optional[Sequence[extensions.Extension]] = None,
-    ) -> "Frame":
+    ) -> Frame:
         """
         Read a WebSocket frame.
 
-        :param reader: coroutine that reads exactly the requested number of
-            bytes, unless the end of file is reached
-        :param mask: whether the frame should be masked i.e. whether the read
-            happens on the server side
-        :param max_size: maximum payload size in bytes
-        :param extensions: list of classes with a ``decode()`` method that
-            transforms the frame and return a new frame; extensions are applied
-            in reverse order
-        :raises ~websockets.exceptions.PayloadTooBig: if the frame exceeds
-            ``max_size``
-        :raises ~websockets.exceptions.ProtocolError: if the frame
-            contains incorrect values
+        Args:
+            reader: coroutine that reads exactly the requested number of
+                bytes, unless the end of file is reached.
+            mask: whether the frame should be masked i.e. whether the read
+                happens on the server side.
+            max_size: maximum payload size in bytes.
+            extensions: list of extensions, applied in reverse order.
+
+        Raises:
+            PayloadTooBig: if the frame exceeds ``max_size``.
+            ProtocolError: if the frame contains incorrect values.
 
         """
 
@@ -142,15 +129,15 @@ class Frame(NamedTuple):
         """
         Write a WebSocket frame.
 
-        :param frame: frame to write
-        :param write: function that writes bytes
-        :param mask: whether the frame should be masked i.e. whether the write
-            happens on the client side
-        :param extensions: list of classes with an ``encode()`` method that
-            transform the frame and return a new frame; extensions are applied
-            in order
-        :raises ~websockets.exceptions.ProtocolError: if the frame
-            contains incorrect values
+        Args:
+            frame: frame to write.
+            write: function that writes bytes.
+            mask: whether the frame should be masked i.e. whether the write
+                happens on the client side.
+            extensions: list of extensions, applied in order.
+
+        Raises:
+            ProtocolError: if the frame contains incorrect values.
 
         """
         # The frame is written in a single call to write in order to prevent
@@ -168,10 +155,12 @@ def parse_close(data: bytes) -> Tuple[int, str]:
     """
     Parse the payload from a close frame.
 
-    Return ``(code, reason)``.
+    Returns:
+        Tuple[int, str]: close code and reason.
 
-    :raises ~websockets.exceptions.ProtocolError: if data is ill-formed
-    :raises UnicodeDecodeError: if the reason isn't valid UTF-8
+    Raises:
+        ProtocolError: if data is ill-formed.
+        UnicodeDecodeError: if the reason isn't valid UTF-8.
 
     """
     return dataclasses.astuple(Close.parse(data))  # type: ignore
@@ -180,8 +169,6 @@ def parse_close(data: bytes) -> Tuple[int, str]:
 def serialize_close(code: int, reason: str) -> bytes:
     """
     Serialize the payload for a close frame.
-
-    This is the reverse of :func:`parse_close`.
 
     """
     return Close(code, reason).serialize()

--- a/src/websockets/legacy/handshake.py
+++ b/src/websockets/legacy/handshake.py
@@ -1,30 +1,3 @@
-"""
-:mod:`websockets.legacy.handshake` provides helpers for the WebSocket handshake.
-
-See `section 4 of RFC 6455`_.
-
-.. _section 4 of RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-4
-
-Some checks cannot be performed because they depend too much on the
-context; instead, they're documented below.
-
-To accept a connection, a server must:
-
-- Read the request, check that the method is GET, and check the headers with
-  :func:`check_request`,
-- Send a 101 response to the client with the headers created by
-  :func:`build_response` if the request is valid; otherwise, send an
-  appropriate HTTP error code.
-
-To open a connection, a client must:
-
-- Send a GET request to the server with the headers created by
-  :func:`build_request`,
-- Read the response, check that the status code is 101, and check the headers
-  with :func:`check_response`.
-
-"""
-
 from __future__ import annotations
 
 import base64
@@ -47,8 +20,11 @@ def build_request(headers: Headers) -> str:
 
     Update request headers passed in argument.
 
-    :param headers: request headers
-    :returns: ``key`` which must be passed to :func:`check_response`
+    Args:
+        headers: handshake request headers.
+
+    Returns:
+        str: ``key`` that must be passed to :func:`check_response`.
 
     """
     key = generate_key()
@@ -68,10 +44,15 @@ def check_request(headers: Headers) -> str:
     are usually performed earlier in the HTTP request handling code. They're
     the responsibility of the caller.
 
-    :param headers: request headers
-    :returns: ``key`` which must be passed to :func:`build_response`
-    :raises ~websockets.exceptions.InvalidHandshake: if the handshake request
-        is invalid; then the server must return 400 Bad Request error
+    Args:
+        headers: handshake request headers.
+
+    Returns:
+        str: ``key`` that must be passed to :func:`build_response`.
+
+    Raises:
+        InvalidHandshake: if the handshake request is invalid;
+            then the server must return 400 Bad Request error.
 
     """
     connection: List[ConnectionOption] = sum(
@@ -128,8 +109,9 @@ def build_response(headers: Headers, key: str) -> None:
 
     Update response headers passed in argument.
 
-    :param headers: response headers
-    :param key: comes from :func:`check_request`
+    Args:
+        headers: handshake response headers.
+        key: returned by :func:`check_request`.
 
     """
     headers["Upgrade"] = "websocket"
@@ -145,10 +127,12 @@ def check_response(headers: Headers, key: str) -> None:
     response with a 101 status code. These controls are the responsibility of
     the caller.
 
-    :param headers: response headers
-    :param key: comes from :func:`build_request`
-    :raises ~websockets.exceptions.InvalidHandshake: if the handshake response
-        is invalid
+    Args:
+        headers: handshake response headers.
+        key: returned by :func:`build_request`.
+
+    Raises:
+        InvalidHandshake: if the handshake response is invalid.
 
     """
     connection: List[ConnectionOption] = sum(

--- a/src/websockets/legacy/http.py
+++ b/src/websockets/legacy/http.py
@@ -55,10 +55,13 @@ async def read_request(stream: asyncio.StreamReader) -> Tuple[str, Headers]:
     WebSocket handshake requests don't have one. If the request contains a
     body, it may be read from ``stream`` after this coroutine returns.
 
-    :param stream: input to read the request from
-    :raises EOFError: if the connection is closed without a full HTTP request
-    :raises SecurityError: if the request exceeds a security limit
-    :raises ValueError: if the request isn't well formatted
+    Args:
+        stream: input to read the request from
+
+    Raises:
+        EOFError: if the connection is closed without a full HTTP request
+        SecurityError: if the request exceeds a security limit
+        ValueError: if the request isn't well formatted
 
     """
     # https://www.rfc-editor.org/rfc/rfc7230.html#section-3.1.1
@@ -99,10 +102,13 @@ async def read_response(stream: asyncio.StreamReader) -> Tuple[int, str, Headers
     WebSocket handshake responses don't have one. If the response contains a
     body, it may be read from ``stream`` after this coroutine returns.
 
-    :param stream: input to read the response from
-    :raises EOFError: if the connection is closed without a full HTTP response
-    :raises SecurityError: if the response exceeds a security limit
-    :raises ValueError: if the response isn't well formatted
+    Args:
+        stream: input to read the response from
+
+    Raises:
+        EOFError: if the connection is closed without a full HTTP response
+        SecurityError: if the response exceeds a security limit
+        ValueError: if the response isn't well formatted
 
     """
     # https://www.rfc-editor.org/rfc/rfc7230.html#section-3.1.2

--- a/src/websockets/streams.py
+++ b/src/websockets/streams.py
@@ -7,8 +7,8 @@ class StreamReader:
     """
     Generator-based stream reader.
 
-    This class doesn't support concurrent calls to :meth:`read_line()`,
-    :meth:`read_exact()`, or :meth:`read_to_eof()`. Make sure calls are
+    This class doesn't support concurrent calls to :meth:`read_line`,
+    :meth:`read_exact`, or :meth:`read_to_eof`. Make sure calls are
     serialized.
 
     """
@@ -21,11 +21,12 @@ class StreamReader:
         """
         Read a LF-terminated line from the stream.
 
-        The return value includes the LF character.
-
         This is a generator-based coroutine.
 
-        :raises EOFError: if the stream ends without a LF
+        The return value includes the LF character.
+
+        Raises:
+            EOFError: if the stream ends without a LF.
 
         """
         n = 0  # number of bytes to read
@@ -44,11 +45,15 @@ class StreamReader:
 
     def read_exact(self, n: int) -> Generator[None, None, bytes]:
         """
-        Read ``n`` bytes from the stream.
+        Read a given number of bytes from the stream.
 
         This is a generator-based coroutine.
 
-        :raises EOFError: if the stream ends in less than ``n`` bytes
+        Args:
+            n: how many bytes to read.
+
+        Raises:
+            EOFError: if the stream ends in less than ``n`` bytes.
 
         """
         assert n >= 0
@@ -92,11 +97,15 @@ class StreamReader:
 
     def feed_data(self, data: bytes) -> None:
         """
-        Write ``data`` to the stream.
+        Write data to the stream.
 
-        :meth:`feed_data()` cannot be called after :meth:`feed_eof()`.
+        :meth:`feed_data` cannot be called after :meth:`feed_eof`.
 
-        :raises EOFError: if the stream has ended
+        Args:
+            data: data to write.
+
+        Raises:
+            EOFError: if the stream has ended.
 
         """
         if self.eof:
@@ -107,9 +116,10 @@ class StreamReader:
         """
         End the stream.
 
-        :meth:`feed_eof()` must be called at must once.
+        :meth:`feed_eof` cannot be called more than once.
 
-        :raises EOFError: if the stream has ended
+        Raises:
+            EOFError: if the stream has ended.
 
         """
         if self.eof:
@@ -118,7 +128,7 @@ class StreamReader:
 
     def discard(self) -> None:
         """
-        Discarding all buffered data, but don't end the stream.
+        Discard all buffered data, but don't end the stream.
 
         """
         del self.buffer[:]

--- a/src/websockets/typing.py
+++ b/src/websockets/typing.py
@@ -17,24 +17,25 @@ __all__ = [
 # Public types used in the signature of public APIs
 
 Data = Union[str, bytes]
-Data.__doc__ = """
-Types supported in a WebSocket message:
+Data.__doc__ = """Types supported in a WebSocket message:
+:class:`str` for a Text_ frame, :class:`bytes` for a Binary_.
 
-- :class:`str` for text messages;
-- :class:`bytes` for binary messages.
+.. _Text: https://www.rfc-editor.org/rfc/rfc6455.html#section-5.6
+.. _Binary : https://www.rfc-editor.org/rfc/rfc6455.html#section-5.6
+
 """
 
 
 LoggerLike = Union[logging.Logger, logging.LoggerAdapter]
-LoggerLike.__doc__ = """Types accepted where :class:`~logging.Logger` is expected."""
+LoggerLike.__doc__ = """Types accepted where a :class:`~logging.Logger` is expected."""
 
 
 Origin = NewType("Origin", str)
-Origin.__doc__ = """Value of a Origin header."""
+Origin.__doc__ = """Value of a ``Origin`` header."""
 
 
 Subprotocol = NewType("Subprotocol", str)
-Subprotocol.__doc__ = """Subprotocol in a Sec-WebSocket-Protocol header."""
+Subprotocol.__doc__ = """Subprotocol in a ``Sec-WebSocket-Protocol`` header."""
 
 
 ExtensionName = NewType("ExtensionName", str)
@@ -48,12 +49,12 @@ ExtensionParameter.__doc__ = """Parameter of a WebSocket extension."""
 # Private types
 
 ExtensionHeader = Tuple[ExtensionName, List[ExtensionParameter]]
-ExtensionHeader.__doc__ = """Extension in a Sec-WebSocket-Extensions header."""
+ExtensionHeader.__doc__ = """Extension in a ``Sec-WebSocket-Extensions`` header."""
 
 
 ConnectionOption = NewType("ConnectionOption", str)
-ConnectionOption.__doc__ = """Connection option in a Connection header."""
+ConnectionOption.__doc__ = """Connection option in a ``Connection`` header."""
 
 
 UpgradeProtocol = NewType("UpgradeProtocol", str)
-UpgradeProtocol.__doc__ = """Upgrade protocol in an Upgrade header."""
+UpgradeProtocol.__doc__ = """Upgrade protocol in an ``Upgrade`` header."""

--- a/src/websockets/uri.py
+++ b/src/websockets/uri.py
@@ -1,12 +1,3 @@
-"""
-:mod:`websockets.uri` parses WebSocket URIs.
-
-See `section 3 of RFC 6455`_.
-
-.. _section 3 of RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-3
-
-"""
-
 from __future__ import annotations
 
 import dataclasses
@@ -24,14 +15,16 @@ class WebSocketURI:
     """
     WebSocket URI.
 
-    :param bool secure: secure flag
-    :param str host: lower-case host
-    :param int port: port, always set even if it's the default
-    :param str resource_name: path and optional query
-    :param str user_info: ``(username, password)`` tuple when the URI contains
-      `User Information`_, else ``None``.
+    Attributes:
+        secure: :obj:`True` for a ``wss`` URI, :obj:`False` for a ``ws`` URI.
+        host: Host, normalized to lower case.
+        port: Port, always set even if it's the default.
+        resource_name: Path and optional query.
+        user_info: ``(username, password)`` when the URI contains
+            `User Information`_, else :obj:`None`.
 
     .. _User Information: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1
+
     """
 
     secure: bool
@@ -49,8 +42,11 @@ def parse_uri(uri: str) -> WebSocketURI:
     """
     Parse and validate a WebSocket URI.
 
-    :raises ~websockets.exceptions.InvalidURI: if ``uri`` isn't a valid
-        WebSocket URI.
+    Args:
+        uri: WebSocket URI.
+
+    Raises:
+        InvalidURI: if ``uri`` isn't a valid WebSocket URI.
 
     """
     parsed = urllib.parse.urlparse(uri)

--- a/src/websockets/utils.py
+++ b/src/websockets/utils.py
@@ -25,7 +25,8 @@ def accept_key(key: str) -> str:
     """
     Compute the value of the Sec-WebSocket-Accept header.
 
-    :param key: value of the Sec-WebSocket-Key header
+    Args:
+        key: value of the Sec-WebSocket-Key header.
 
     """
     sha1 = hashlib.sha1((key + GUID).encode()).digest()
@@ -36,8 +37,9 @@ def apply_mask(data: bytes, mask: bytes) -> bytes:
     """
     Apply masking to the data of a WebSocket message.
 
-    :param data: Data to mask
-    :param mask: 4-bytes mask
+    Args:
+        data: data to mask.
+        mask: 4-bytes mask.
 
     """
     if len(mask) != 4:


### PR DESCRIPTION
Remove sphinx-autodoc-typehints and use native autodoc features
instead, mainly because I can't find a workaround for:
https://github.com/agronholm/sphinx-autodoc-typehints/issues/132

Re-introduce the "common" docs, else linking to send() and recv()
is a mess.