### PR TITLE
Version bump cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         platforms: all
     - name: Build wheels
-      uses: joerick/cibuildwheel@v1.11.0
+      uses: pypa/cibuildwheel@v2.2.0
       env:
         CIBW_ARCHS_LINUX: auto aarch64
         CIBW_SKIP: cp36-*


### PR DESCRIPTION
update cibuildwheel to newer version. One of the benefits is 3.10 support and musslinux wheels.