### PR TITLE
Don't rely on `git` being on the path

### DIFF
--- a/src/websockets/version.py
+++ b/src/websockets/version.py
@@ -42,7 +42,7 @@ if not released:  # pragma: no cover
                 check=True,
                 text=True,
             ).stdout.strip()
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             pass
         else:
             description_re = r"[0-9.]+-([0-9]+)-(g[0-9a-f]{7}(?:-dirty)?)"


### PR DESCRIPTION
Allow version check to ignore `git` if the command is not available on the path.