### PR TITLE
Fix file descriptors leaking when connection was cancelled

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -663,7 +663,7 @@ class Connect:
                         available_subprotocols=protocol.available_subprotocols,
                         extra_headers=protocol.extra_headers,
                     )
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     protocol.fail_connection()
                     await protocol.wait_closed()
                     raise


### PR DESCRIPTION
Since python3.8 CancelledError is subclass of BaseException

Test server is spawned in separate process to avoid counting server sockets

Closes: #1113