### PR TITLE
Add a new line about client.connect() and asyncio.loop.create_connection() accept the same arguments

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -344,6 +344,8 @@ class Connect:
     """
     Connect to the WebSocket server at ``uri``.
 
+    :func:`connect` accepts the same arguments as :meth:`~asyncio.loop.create_connection`.
+
     Awaiting :func:`connect` yields a :class:`WebSocketClientProtocol` which
     can then be used to send and receive messages.
 


### PR DESCRIPTION
It wasn't very clear in [documentation](https://websockets.readthedocs.io/en/stable/reference/client.html), and I didn't know about this until I see the same line in this [FAQ section](https://websockets.readthedocs.io/en/stable/howto/faq.html#how-do-i-disable-tls-ssl-certificate-verification). I didn't know I could pass `sock` parameter to `client.connect()` because it wasn't mentioned.