### PR TITLE
Fix unsafe reference to self.pings with a variable

### DIFF
--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -846,11 +846,12 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         while data is None or data in self.pings:
             data = struct.pack("!I", random.getrandbits(32))
 
-        self.pings[data] = self.loop.create_future()
+        ping_future = self.loop.create_future()
+        self.pings[data] = ping_future
 
         await self.write_frame(True, OP_PING, data)
 
-        return asyncio.shield(self.pings[data])
+        return asyncio.shield(ping_future)
 
     async def pong(self, data: Data = b"") -> None:
         """


### PR DESCRIPTION
Due to context switch during `await self.write_frame(True, OP_PING, data)` in the ping method, the relevant key in self.pings gets deleted resulting in a KeyError at `return asyncio.shield(self.pings[data])`, which in turn crashes the keepalive_ping task.

https://github.com/aaugustin/websockets/blob/c4a4b6f45af607431c5707d56420bbaf471bbb6e/src/websockets/legacy/protocol.py#L849-L853

This bug can be consistently reproduced while sending a fragmented message (the first keepalive ping always fails during my tests). 
