### PR TITLE
Add explanation of imports to API reference

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -61,6 +61,8 @@ guarantees of behavior or backwards-compatibility for private APIs.
 For convenience, many public APIs can be imported from the ``websockets``
 package. However, this feature is incompatible with static code analysis. It
 breaks autocompletion in an IDE or type checking with mypy_. If you're using
-such tools, use the real import paths.
+such tools, use the real import paths. To do this, you must import modules via
+``from websockets import <module>`` or to access a specific exported value
+``from websockets.<module> import <exported_value>``.
 
 .. _mypy: https://github.com/python/mypy


### PR DESCRIPTION
Yesterday, while trying to type check my code using the `websockets` library, I was getting quite frustrated. All of the example code seemed to show `import websockets` and then accessing everything directly off the package, which doesn't support type checking or code completion because of the lazy import system. I nearly opened an issue about the matter to see what I was doing wrong, when I then went to double check that there wasn't an existing issue about it before filing. Lo and behold, I found https://github.com/aaugustin/websockets/issues/940#issuecomment-874012438 which gave me what I needed to start type checking my code that uses `websockets`.

I couldn't find this directly provided as an example or in any of the example code I saw in the docs, but while digging around did see this reference to "use the real import path" at the bottom of the API reference index, without really elaborating on what that is. I consider myself a reasonably experienced python dev and was surprised/confused at first to see `import websockets` not exposing any of the modules to my IDE but `from websockets import ` exposing all available modules (and thereby giving my autocomplete and letting mypy type check correctly).

So rather than just raise another issue complaining that I couldn't figure it out, I thought I'd add in a couple more lines to the docs to explain what "use the real import paths" actually looks like in code.

I also considered perhaps adding a note to the [types](https://websockets.readthedocs.io/en/stable/reference/types.html) page of the docs, but felt that wasn't really the correct place since that's a proper API reference. I also thought about maybe a new docs page in the [how-to guides](https://websockets.readthedocs.io/en/stable/howto/index.html) about how to use the websockets library in a way that your IDE and type checkers know what's going on, but thought I'd start with this simple change first.