### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -1303,7 +1303,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
             if self.is_client and hasattr(self, "transfer_data_task"):
                 if await self.wait_for_connection_lost():
                     # Coverage marks this line as a partially executed branch.
-                    # I supect a bug in coverage. Ignore it for now.
+                    # I suspect a bug in coverage. Ignore it for now.
                     return  # pragma: no cover
                 if self.debug:
                     self.logger.debug("! timed out waiting for TCP close")
@@ -1323,7 +1323,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
 
                 if await self.wait_for_connection_lost():
                     # Coverage marks this line as a partially executed branch.
-                    # I supect a bug in coverage. Ignore it for now.
+                    # I suspect a bug in coverage. Ignore it for now.
                     return  # pragma: no cover
                 if self.debug:
                     self.logger.debug("! timed out waiting for TCP close")
@@ -1361,7 +1361,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
 
         # connection_lost() is called quickly after aborting.
         # Coverage marks this line as a partially executed branch.
-        # I supect a bug in coverage. Ignore it for now.
+        # I suspect a bug in coverage. Ignore it for now.
         await self.wait_for_connection_lost()  # pragma: no cover
 
     async def wait_for_connection_lost(self) -> bool:

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -153,7 +153,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         Handle the lifecycle of a WebSocket connection.
 
         Since this method doesn't have a caller able to handle exceptions, it
-        attemps to log relevant ones and guarantees that the TCP connection is
+        attempts to log relevant ones and guarantees that the TCP connection is
         closed before exiting.
 
         """

--- a/tests/legacy/test_protocol.py
+++ b/tests/legacy/test_protocol.py
@@ -1188,7 +1188,7 @@ class CommonTests:
     def test_keepalive_ping_not_acknowledged_closes_connection(self):
         self.restart_protocol_with_keepalive_ping()
 
-        # Ping is sent at 3ms and not acknowleged.
+        # Ping is sent at 3ms and not acknowledged.
         self.loop.run_until_complete(asyncio.sleep(4 * MS))
         (ping_1,) = tuple(self.protocol.pings)
         self.assertOneFrameSent(True, OP_PING, ping_1)
@@ -1257,7 +1257,7 @@ class CommonTests:
     def test_keepalive_ping_with_no_ping_timeout(self):
         self.restart_protocol_with_keepalive_ping(ping_timeout=None)
 
-        # Ping is sent at 3ms and not acknowleged.
+        # Ping is sent at 3ms and not acknowledged.
         self.loop.run_until_complete(asyncio.sleep(4 * MS))
         (ping_1,) = tuple(self.protocol.pings)
         self.assertOneFrameSent(True, OP_PING, ping_1)

--- a/tests/legacy/utils.py
+++ b/tests/legacy/utils.py
@@ -18,7 +18,7 @@ class AsyncioTestCase(unittest.TestCase):
         """
         Convert test coroutines to test functions.
 
-        This supports asychronous tests transparently.
+        This supports asynchronous tests transparently.
 
         """
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
There are small typos in:
- src/websockets/legacy/protocol.py
- src/websockets/legacy/server.py
- tests/legacy/test_protocol.py
- tests/legacy/utils.py

Fixes:
- Should read `suspect` rather than `supect`.
- Should read `acknowledged` rather than `acknowleged`.
- Should read `attempts` rather than `attemps`.
- Should read `asynchronous` rather than `asychronous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md