### PR TITLE
Default values for Optional fields in WebSocketURI

### DIFF
--- a/src/websockets/uri.py
+++ b/src/websockets/uri.py
@@ -33,8 +33,8 @@ class WebSocketURI:
     port: int
     path: str
     query: str
-    username: Optional[str]
-    password: Optional[str]
+    username: Optional[str] = None
+    password: Optional[str] = None
 
     @property
     def resource_name(self) -> str:


### PR DESCRIPTION
Hello!

Due to the nature of dataclasses in Python, for a field to be truly optional, it must be provided with a default value, not only `Optional` annotation. Otherwise, when creating `WebSocketURI` сlass instance without `login` and `password`, we will get an error like:
```
TypeError: WebSocketURI.init() missing 2 required positional arguments: 'username' and 'password'
```
Judging by the code, this was an accidental oversight, because checking for `None` value of the `name` and `password` already exists and the rest of the project code has default values for dataclasses.

Thanks in advance.