### PR TITLE
feat: added support for no-server-header and no-date-header

### DIFF
--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -65,8 +65,8 @@ class ClientConnection(Connection):
             defaults to ``logging.getLogger("websockets.client")``;
             see the :doc:`logging guide <../topics/logging>` for details.
         user_agent_header: User-Agent header that gets defined
-            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
-            to disable the header assign `None`
+            defaults to ``f"Python/{PYTHON_VERSION} websockets/{websockets_version}"``
+            to disable the header assign ``None``
 
     """
 

--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -76,7 +76,7 @@ class ClientConnection(Connection):
         state: State = CONNECTING,
         max_size: Optional[int] = 2**20,
         logger: Optional[LoggerLike] = None,
-        user_agent_header: Optional[str] = USER_AGENT
+        user_agent_header: Optional[str] = USER_AGENT,
     ):
         super().__init__(
             side=CLIENT,

--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -64,6 +64,9 @@ class ClientConnection(Connection):
         logger: logger for this connection;
             defaults to ``logging.getLogger("websockets.client")``;
             see the :doc:`logging guide <../topics/logging>` for details.
+        user_agent_header: User-Agent header that gets defined
+            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
+            to disable the header assign `None`
 
     """
 

--- a/src/websockets/client.py
+++ b/src/websockets/client.py
@@ -76,6 +76,7 @@ class ClientConnection(Connection):
         state: State = CONNECTING,
         max_size: Optional[int] = 2**20,
         logger: Optional[LoggerLike] = None,
+        user_agent_header: Optional[str] = USER_AGENT
     ):
         super().__init__(
             side=CLIENT,
@@ -88,6 +89,7 @@ class ClientConnection(Connection):
         self.available_extensions = extensions
         self.available_subprotocols = subprotocols
         self.key = generate_key()
+        self.user_agent_header = user_agent_header
 
     def connect(self) -> Request:  # noqa: F811
         """
@@ -131,7 +133,8 @@ class ClientConnection(Connection):
             protocol_header = build_subprotocol(self.available_subprotocols)
             headers["Sec-WebSocket-Protocol"] = protocol_header
 
-        headers["User-Agent"] = USER_AGENT
+        if self.user_agent_header:
+            headers["User-Agent"] = self.user_agent_header
 
         return Request(self.wsuri.resource_name, headers)
 

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -89,6 +89,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         extensions: Optional[Sequence[ClientExtensionFactory]] = None,
         subprotocols: Optional[Sequence[Subprotocol]] = None,
         extra_headers: Optional[HeadersLike] = None,
+        no_server_header: bool = False,
         **kwargs: Any,
     ) -> None:
         if logger is None:
@@ -98,6 +99,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         self.available_extensions = extensions
         self.available_subprotocols = subprotocols
         self.extra_headers = extra_headers
+        self.no_server_header = no_server_header
 
     def write_http_request(self, path: str, headers: Headers) -> None:
         """
@@ -315,7 +317,8 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         if self.extra_headers is not None:
             request_headers.update(self.extra_headers)
 
-        request_headers.setdefault("User-Agent", USER_AGENT)
+        if not self.no_server_header:
+            request_headers.setdefault("User-Agent", USER_AGENT)
 
         self.write_http_request(wsuri.resource_name, request_headers)
 

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -398,6 +398,9 @@ class Connect:
         extra_headers: arbitrary HTTP headers to add to the request.
         open_timeout: timeout for opening the connection in seconds;
             :obj:`None` to disable the timeout
+        user_agent_header: User-Agent header that gets defined
+            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
+            to disable the header assign `None`
 
     See :class:`~websockets.legacy.protocol.WebSocketCommonProtocol` for the
     documentation of ``ping_interval``, ``ping_timeout``, ``close_timeout``,

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -89,7 +89,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         extensions: Optional[Sequence[ClientExtensionFactory]] = None,
         subprotocols: Optional[Sequence[Subprotocol]] = None,
         extra_headers: Optional[HeadersLike] = None,
-        no_server_header: bool = False,
+        user_agent_header: Optional[str] = USER_AGENT,
         **kwargs: Any,
     ) -> None:
         if logger is None:
@@ -99,7 +99,7 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         self.available_extensions = extensions
         self.available_subprotocols = subprotocols
         self.extra_headers = extra_headers
-        self.no_server_header = no_server_header
+        self.user_agent_header = user_agent_header
 
     def write_http_request(self, path: str, headers: Headers) -> None:
         """
@@ -317,8 +317,8 @@ class WebSocketClientProtocol(WebSocketCommonProtocol):
         if self.extra_headers is not None:
             request_headers.update(self.extra_headers)
 
-        if not self.no_server_header:
-            request_headers.setdefault("User-Agent", USER_AGENT)
+        if self.user_agent_header:
+            request_headers.setdefault("User-Agent", self.user_agent_header)
 
         self.write_http_request(wsuri.resource_name, request_headers)
 

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -399,8 +399,8 @@ class Connect:
         open_timeout: timeout for opening the connection in seconds;
             :obj:`None` to disable the timeout
         user_agent_header: User-Agent header that gets defined
-            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
-            to disable the header assign `None`
+            defaults to ``f"Python/{PYTHON_VERSION} websockets/{websockets_version}"``
+            to disable the header assign ``None``
 
     See :class:`~websockets.legacy.protocol.WebSocketCommonProtocol` for the
     documentation of ``ping_interval``, ``ping_timeout``, ``close_timeout``,

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -519,7 +519,7 @@ class Connect:
             secure=wsuri.secure,
             legacy_recv=legacy_recv,
             loop=_loop,
-            user_agent_header=user_agent_header
+            user_agent_header=user_agent_header,
         )
 
         if kwargs.pop("unix", False):

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -449,6 +449,7 @@ class Connect:
         max_queue: Optional[int] = 2**5,
         read_limit: int = 2**16,
         write_limit: int = 2**16,
+        user_agent_header: Optional[str] = USER_AGENT,
         **kwargs: Any,
     ) -> None:
         # Backwards compatibility: close_timeout used to be called timeout.
@@ -518,6 +519,7 @@ class Connect:
             secure=wsuri.secure,
             legacy_recv=legacy_recv,
             loop=_loop,
+            user_agent_header=user_agent_header
         )
 
         if kwargs.pop("unix", False):

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -84,7 +84,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         ws_server: WebSocket server that created this connection.
 
     See :func:`serve` for the documentation of ``ws_handler``, ``logger``, ``origins``,
-    ``extensions``, ``subprotocols``, and ``extra_headers``.
+    ``extensions``, ``subprotocols``, ``extra_headers``, and ``server_header``.
 
     See :class:`~websockets.legacy.protocol.WebSocketCommonProtocol` for the
     documentation of ``ping_interval``, ``ping_timeout``, ``close_timeout``,
@@ -949,6 +949,9 @@ class Serve:
             see :meth:`~WebSocketServerProtocol.process_request` for details.
         select_subprotocol: select a subprotocol supported by the client;
             see :meth:`~WebSocketServerProtocol.select_subprotocol` for details.
+        server_header Optional[str]: Server header that gets defined
+            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
+            to disable the header assign `None`
 
     See :class:`~websockets.legacy.protocol.WebSocketCommonProtocol` for the
     documentation of ``ping_interval``, ``ping_timeout``, ``close_timeout``,

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -980,6 +980,7 @@ class Serve:
         max_queue: Optional[int] = 2**5,
         read_limit: int = 2**16,
         write_limit: int = 2**16,
+        server_header: Optional[str] = USER_AGENT,
         **kwargs: Any,
     ) -> None:
         # Backwards compatibility: close_timeout used to be called timeout.
@@ -1051,6 +1052,7 @@ class Serve:
             process_request=process_request,
             select_subprotocol=select_subprotocol,
             logger=logger,
+            server_header=server_header,
         )
 
         if kwargs.pop("unix", False):

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -114,7 +114,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         select_subprotocol: Optional[
             Callable[[Sequence[Subprotocol], Sequence[Subprotocol]], Subprotocol]
         ] = None,
-        no_server_header: bool = False,
+        server_header: Optional[str] = USER_AGENT,
         **kwargs: Any,
     ) -> None:
         if logger is None:
@@ -135,7 +135,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         self.extra_headers = extra_headers
         self._process_request = process_request
         self._select_subprotocol = select_subprotocol
-        self.no_server_header = no_server_header
+        self.server_header = server_header
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """
@@ -218,8 +218,8 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                     )
 
                 headers.setdefault("Date", email.utils.formatdate(usegmt=True))
-                if not self.no_server_header:
-                    headers.setdefault("Server", USER_AGENT)
+                if self.server_header:
+                    headers.setdefault("Server", self.server_header)
                 headers.setdefault("Content-Length", str(len(body)))
                 headers.setdefault("Content-Type", "text/plain")
                 headers.setdefault("Connection", "close")
@@ -638,8 +638,9 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             response_headers.update(extra_headers)
 
         response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
-        if not self.no_server_header:
-            response_headers.setdefault("Server", USER_AGENT)
+
+        if self.server_header:
+            response_headers.setdefault("Server", self.server_header)
 
         self.write_http_response(http.HTTPStatus.SWITCHING_PROTOCOLS, response_headers)
 

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -115,7 +115,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
             Callable[[Sequence[Subprotocol], Sequence[Subprotocol]], Subprotocol]
         ] = None,
         no_server_header: bool = False,
-        no_date_header: bool = False,
         **kwargs: Any,
     ) -> None:
         if logger is None:
@@ -137,7 +136,6 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         self._process_request = process_request
         self._select_subprotocol = select_subprotocol
         self.no_server_header = no_server_header
-        self.no_date_header = no_date_header
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """
@@ -219,8 +217,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
                         ),
                     )
 
-                if not self.no_date_header:
-                    headers.setdefault("Date", email.utils.formatdate(usegmt=True))
+                headers.setdefault("Date", email.utils.formatdate(usegmt=True))
                 if not self.no_server_header:
                     headers.setdefault("Server", USER_AGENT)
                 headers.setdefault("Content-Length", str(len(body)))
@@ -640,8 +637,7 @@ class WebSocketServerProtocol(WebSocketCommonProtocol):
         if extra_headers is not None:
             response_headers.update(extra_headers)
 
-        if not self.no_date_header:
-            response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
+        response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
         if not self.no_server_header:
             response_headers.setdefault("Server", USER_AGENT)
 

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -950,8 +950,8 @@ class Serve:
         select_subprotocol: select a subprotocol supported by the client;
             see :meth:`~WebSocketServerProtocol.select_subprotocol` for details.
         server_header Optional[str]: Server header that gets defined
-            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
-            to disable the header assign `None`
+            defaults to ``f"Python/{PYTHON_VERSION} websockets/{websockets_version}"``
+            to disable the header assign ``None``
 
     See :class:`~websockets.legacy.protocol.WebSocketCommonProtocol` for the
     documentation of ``ping_interval``, ``ping_timeout``, ``close_timeout``,

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -64,6 +64,10 @@ class ServerConnection(Connection):
         logger: logger for this connection;
             defaults to ``logging.getLogger("websockets.client")``;
             see the :doc:`logging guide <../topics/logging>` for details.
+        server_header: Server header that gets defined
+            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
+            to disable the header assign `None`
+
 
     """
 

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -76,7 +76,6 @@ class ServerConnection(Connection):
         max_size: Optional[int] = 2**20,
         logger: Optional[LoggerLike] = None,
         no_server_header: bool = False,
-        no_date_header: bool = False,
     ):
         super().__init__(
             side=SERVER,
@@ -88,7 +87,6 @@ class ServerConnection(Connection):
         self.available_extensions = extensions
         self.available_subprotocols = subprotocols
         self.no_server_header = no_server_header
-        self.no_date_header = no_date_header
 
     def accept(self, request: Request) -> Response:
         """
@@ -162,8 +160,7 @@ class ServerConnection(Connection):
 
         headers = Headers()
 
-        if not self.no_date_header:
-            headers["Date"] = email.utils.formatdate(usegmt=True)
+        headers["Date"] = email.utils.formatdate(usegmt=True)
 
         headers["Upgrade"] = "websocket"
         headers["Connection"] = "Upgrade"
@@ -476,8 +473,8 @@ class ServerConnection(Connection):
             ]
         if not self.no_server_header:
             headers_list.append(("Server", USER_AGENT))
-        if not self.no_date_header:
-            headers_list.append(("Date", email.utils.formatdate(usegmt=True)))
+
+        headers_list.append(("Date", email.utils.formatdate(usegmt=True)))
         headers = Headers(headers_list)
 
         response = Response(status.value, status.phrase, headers, body)

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -466,16 +466,16 @@ class ServerConnection(Connection):
 
         """
         body = text.encode()
-        headers_list = [
+        headers = Headers(
+            [
+                ("Date", email.utils.formatdate(usegmt=True)),
                 ("Connection", "close"),
                 ("Content-Length", str(len(body))),
                 ("Content-Type", "text/plain; charset=utf-8"),
             ]
+        )
         if self.server_header:
-            headers_list.append(("Server", self.server_header))
-
-        headers_list.append(("Date", email.utils.formatdate(usegmt=True)))
-        headers = Headers(headers_list)
+            headers["Server"] = self.server_header
 
         response = Response(status.value, status.phrase, headers, body)
         # When reject() is called from accept(), handshake_exc is already set.

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -65,8 +65,8 @@ class ServerConnection(Connection):
             defaults to ``logging.getLogger("websockets.client")``;
             see the :doc:`logging guide <../topics/logging>` for details.
         server_header: Server header that gets defined
-            defaults to `f"Python/{PYTHON_VERSION} websockets/{websockets_version}"`
-            to disable the header assign `None`
+            defaults to ``f"Python/{PYTHON_VERSION} websockets/{websockets_version}"``
+            to disable the header assign ``None``
 
 
     """

--- a/src/websockets/server.py
+++ b/src/websockets/server.py
@@ -75,7 +75,7 @@ class ServerConnection(Connection):
         state: State = CONNECTING,
         max_size: Optional[int] = 2**20,
         logger: Optional[LoggerLike] = None,
-        no_server_header: bool = False,
+        server_header: Optional[str] = USER_AGENT,
     ):
         super().__init__(
             side=SERVER,
@@ -86,7 +86,7 @@ class ServerConnection(Connection):
         self.origins = origins
         self.available_extensions = extensions
         self.available_subprotocols = subprotocols
-        self.no_server_header = no_server_header
+        self.server_header = server_header
 
     def accept(self, request: Request) -> Response:
         """
@@ -172,8 +172,8 @@ class ServerConnection(Connection):
         if protocol_header is not None:
             headers["Sec-WebSocket-Protocol"] = protocol_header
 
-        if self.no_server_header:
-            headers["Server"] = USER_AGENT
+        if self.server_header:
+            headers["Server"] = self.server_header
 
         self.logger.info("connection open")
         return Response(101, "Switching Protocols", headers)
@@ -471,8 +471,8 @@ class ServerConnection(Connection):
                 ("Content-Length", str(len(body))),
                 ("Content-Type", "text/plain; charset=utf-8"),
             ]
-        if not self.no_server_header:
-            headers_list.append(("Server", USER_AGENT))
+        if self.server_header:
+            headers_list.append(("Server", self.server_header))
 
         headers_list.append(("Date", email.utils.formatdate(usegmt=True)))
         headers = Headers(headers_list)

--- a/src/websockets/uri.py
+++ b/src/websockets/uri.py
@@ -33,8 +33,8 @@ class WebSocketURI:
     port: int
     path: str
     query: str
-    username: Optional[str]
-    password: Optional[str]
+    username: Optional[str] = None
+    password: Optional[str] = None
 
     @property
     def resource_name(self) -> str:

--- a/tests/legacy/test_client_server.py
+++ b/tests/legacy/test_client_server.py
@@ -1227,6 +1227,20 @@ class CommonClientServerTests:
         # Connection ends with an abnormal closure.
         self.assertEqual(self.client.close_code, 1006)
 
+    @with_server(server_header=None)
+    @with_client("/headers")
+    def test_protocol_custom_response_server_header_none(self):
+        self.loop.run_until_complete(self.client.recv())
+        resp_headers = self.loop.run_until_complete(self.client.recv())
+        self.assertEqual(resp_headers.count("Server"), 0)
+
+    @with_server()
+    @with_client("/headers", user_agent_header=None)
+    def test_protocol_custom_request_user_agent_header_none(self):
+        req_headers = self.loop.run_until_complete(self.client.recv())
+        self.loop.run_until_complete(self.client.recv())
+        self.assertEqual(req_headers.count("User-Agent"), 0)
+
 
 class ClientServerTests(
     CommonClientServerTests, ClientServerTestsMixin, AsyncioTestCase

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,6 @@ from websockets.http import USER_AGENT
 from websockets.http11 import Request, Response
 from websockets.uri import parse_uri
 from websockets.utils import accept_key
-
 from .extensions.utils import (
     ClientOpExtensionFactory,
     ClientRsv2ExtensionFactory,
@@ -573,6 +572,22 @@ class AcceptRejectTests(unittest.TestCase):
         with self.assertRaises(InvalidHandshake) as raised:
             raise client.handshake_exc
         self.assertEqual(str(raised.exception), "unsupported subprotocol: otherchat")
+
+    def test_user_agent_header_none(self):
+        client = ClientConnection(
+            parse_uri("wss://example.com/"),
+            user_agent_header=None,
+        )
+        request = client.connect()
+        self.assertNotIn("User-Agent", request.headers)
+
+    def test_custom_user_agent_header(self):
+        client = ClientConnection(
+            parse_uri("wss://example.com/"),
+            user_agent_header="Eggs"
+        )
+        request = client.connect()
+        self.assertEqual(request.headers.get("User-Agent"), "Eggs")
 
 
 class MiscTests(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -583,8 +583,7 @@ class AcceptRejectTests(unittest.TestCase):
 
     def test_custom_user_agent_header(self):
         client = ClientConnection(
-            parse_uri("wss://example.com/"),
-            user_agent_header="Eggs"
+            parse_uri("wss://example.com/"), user_agent_header="Eggs"
         )
         request = client.connect()
         self.assertEqual(request.headers.get("User-Agent"), "Eggs")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -620,6 +620,16 @@ class AcceptRejectTests(unittest.TestCase):
         response = server.accept(request)
         self.assertEqual(response.headers.get("server"), "Eggs")
 
+    def test_reject_response_server_header_none(self):
+        server = ServerConnection(server_header=None)
+        with unittest.mock.patch("email.utils.formatdate", return_value=DATE):
+            response = server.reject(http.HTTPStatus.NOT_FOUND, "Sorry folks.\n")
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.reason_phrase, "Not Found")
+        self.assertNotIn("Server", response.headers)
+        self.assertEqual(response.body, b"Sorry folks.\n")
+
 
 class MiscTests(unittest.TestCase):
     def test_bypass_handshake(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -608,6 +608,18 @@ class AcceptRejectTests(unittest.TestCase):
         self.assertNotIn("Sec-WebSocket-Protocol", response.headers)
         self.assertIsNone(server.subprotocol)
 
+    def test_server_header_none(self):
+        server = ServerConnection(server_header=None)
+        request = self.make_request()
+        response = server.accept(request)
+        self.assertNotIn("Server", response.headers)
+
+    def test_custom_server_header(self):
+        server = ServerConnection(server_header="Eggs")
+        request = self.make_request()
+        response = server.accept(request)
+        self.assertEqual(response.headers.get("server"), "Eggs")
+
 
 class MiscTests(unittest.TestCase):
     def test_bypass_handshake(self):


### PR DESCRIPTION
I have added keyword arguments to not add server header and date header. 

This fixes issue discussed in https://github.com/aaugustin/websockets/issues/1193

Please let me know if this is okay. I will add necessary test and docs. 