### PR TITLE
Refactor create_protocol to represent the real type

### DIFF
--- a/src/websockets/legacy/auth.py
+++ b/src/websockets/legacy/auth.py
@@ -118,7 +118,7 @@ def basic_auth_protocol_factory(
     realm: Optional[str] = None,
     credentials: Optional[Union[Credentials, Iterable[Credentials]]] = None,
     check_credentials: Optional[Callable[[str, str], Awaitable[bool]]] = None,
-    create_protocol: Optional[Callable[[Any], BasicAuthWebSocketServerProtocol]] = None,
+    create_protocol: Optional[Callable[..., BasicAuthWebSocketServerProtocol]] = None,
 ) -> Callable[[Any], BasicAuthWebSocketServerProtocol]:
     """
     Protocol factory that enforces HTTP Basic Auth.

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -438,7 +438,7 @@ class Connect:
         self,
         uri: str,
         *,
-        create_protocol: Optional[Callable[[Any], WebSocketClientProtocol]] = None,
+        create_protocol: Optional[Callable[..., WebSocketClientProtocol]] = None,
         logger: Optional[LoggerLike] = None,
         compression: Optional[str] = "deflate",
         origin: Optional[Origin] = None,

--- a/src/websockets/legacy/server.py
+++ b/src/websockets/legacy/server.py
@@ -991,7 +991,7 @@ class Serve:
         host: Optional[Union[str, Sequence[str]]] = None,
         port: Optional[int] = None,
         *,
-        create_protocol: Optional[Callable[[Any], WebSocketServerProtocol]] = None,
+        create_protocol: Optional[Callable[..., WebSocketServerProtocol]] = None,
         logger: Optional[LoggerLike] = None,
         compression: Optional[str] = "deflate",
         origins: Optional[Sequence[Optional[Origin]]] = None,


### PR DESCRIPTION
`[Any]` means one argument of `Any` type, `...` means "ignore". This is relevant since `WebSocketServerProtocol` and similar in fact have multiple arguments. Ideally a `Protocol` with a `__call__` method included should be used, but that's up for discussion since that would add maintainability issues as the signature would be duplicated in multiple places.

**Or**, `Type[WebSocketServerProtocol]` *may* work too.