### PR TITLE
Fix the code of "How can I pass arguments to a custom protocol subclass?" in docs

### DIFF
--- a/docs/faq/common.rst
+++ b/docs/faq/common.rst
@@ -125,9 +125,9 @@ You can bind additional arguments to the protocol factory with
     import websockets
 
     class MyServerProtocol(websockets.WebSocketServerProtocol):
-        def __init__(self, extra_argument, *args, **kwargs):
+        def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            # do something with extra_argument
+            # do something with kwargs['extra_argument']
 
     create_protocol = functools.partial(MyServerProtocol, extra_argument='spam')
     start_server = websockets.serve(..., create_protocol=create_protocol)


### PR DESCRIPTION
Fix the code of ["How can I pass arguments to a custom protocol subclass?"](https://websockets.readthedocs.io/en/stable/faq/common.html#how-can-i-pass-arguments-to-a-custom-protocol-subclass)

For #1275