### PR TITLE
Set server_hostname automatically when needed

### DIFF
--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -535,6 +535,8 @@ class Connect:
             else:
                 # If sock is given, host and port shouldn't be specified.
                 host, port = None, None
+                if kwargs.get("ssl"):
+                    kwargs.setdefault("server_hostname", wsuri.host)
             # If host and port are given, override values from the URI.
             host = kwargs.pop("host", host)
             port = kwargs.pop("port", port)


### PR DESCRIPTION
`create_connection` requires either `host` or `server_hostname` if `ssl` is truthy. If `sock` is given, `host` gets unset, so provide `server_hostname` with the URI host if needed and not already provided by the caller.