### PR TITLE
Switch to using asyncio.timeout instead of asyncio.wait_for

### DIFF
--- a/docs/faq/common.rst
+++ b/docs/faq/common.rst
@@ -105,9 +105,14 @@ you can adjust it with the ``ping_timeout`` argument.
 How do I set a timeout on :meth:`~legacy.protocol.WebSocketCommonProtocol.recv`?
 --------------------------------------------------------------------------------
 
-Use :func:`~asyncio.wait_for`::
+On Python ≥ 3.11, use :func:`asyncio.timeout`::
 
-    await asyncio.wait_for(websocket.recv(), timeout=10)
+    async with asyncio.timeout(timeout=10):
+        message = await websocket.recv()
+
+On older versions of Python, use :func:`asyncio.wait_for`::
+
+    message = await asyncio.wait_for(websocket.recv(), timeout=10)
 
 This technique works for most APIs. When it doesn't, for example with
 asynchronous context managers, websockets provides an ``open_timeout`` argument.

--- a/docs/topics/design.rst
+++ b/docs/topics/design.rst
@@ -437,7 +437,7 @@ propagate cancellation to them.
 prevent cancellation.
 
 :meth:`~legacy.protocol.WebSocketCommonProtocol.close` waits for the data transfer
-task to terminate with :func:`~asyncio.wait_for`. If it's canceled or if the
+task to terminate with :func:`~asyncio.timeout`. If it's canceled or if the
 timeout elapses, :attr:`~legacy.protocol.WebSocketCommonProtocol.transfer_data_task`
 is canceled, which is correct at this point.
 :meth:`~legacy.protocol.WebSocketCommonProtocol.close` then waits for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ branch = true
 omit = [
     # */websockets matches src/websockets and .tox/**/site-packages/websockets
     "*/websockets/__main__.py",
+    "*/websockets/legacy/async_timeout.py",
     "*/websockets/legacy/compatibility.py",
     "tests/maxi_cov.py",
 ]

--- a/src/websockets/legacy/async_timeout.py
+++ b/src/websockets/legacy/async_timeout.py
@@ -1,0 +1,225 @@
+# From https://github.com/aio-libs/async-timeout/blob/master/async_timeout/__init__.py
+# Licensed under the Apache License, Version 2.0.
+
+import asyncio
+import enum
+import sys
+import warnings
+from types import TracebackType
+from typing import Optional, Type
+
+
+if sys.version_info >= (3, 8):
+    from typing import final
+else:
+    from typing_extensions import final
+
+
+__version__ = "4.0.2"
+
+
+__all__ = ("timeout", "timeout_at", "Timeout")
+
+
+def timeout(delay: Optional[float]) -> "Timeout":
+    """timeout context manager.
+
+    Useful in cases when you want to apply timeout logic around block
+    of code or in cases when asyncio.wait_for is not suitable. For example:
+
+    >>> async with timeout(0.001):
+    ...     async with aiohttp.get('https://github.com') as r:
+    ...         await r.text()
+
+
+    delay - value in seconds or None to disable timeout logic
+    """
+    loop = asyncio.get_running_loop()
+    if delay is not None:
+        deadline = loop.time() + delay  # type: Optional[float]
+    else:
+        deadline = None
+    return Timeout(deadline, loop)
+
+
+def timeout_at(deadline: Optional[float]) -> "Timeout":
+    """Schedule the timeout at absolute time.
+
+    deadline argument points on the time in the same clock system
+    as loop.time().
+
+    Please note: it is not POSIX time but a time with
+    undefined starting base, e.g. the time of the system power on.
+
+    >>> async with timeout_at(loop.time() + 10):
+    ...     async with aiohttp.get('https://github.com') as r:
+    ...         await r.text()
+
+
+    """
+    loop = asyncio.get_running_loop()
+    return Timeout(deadline, loop)
+
+
+class _State(enum.Enum):
+    INIT = "INIT"
+    ENTER = "ENTER"
+    TIMEOUT = "TIMEOUT"
+    EXIT = "EXIT"
+
+
+@final
+class Timeout:
+    # Internal class, please don't instantiate it directly
+    # Use timeout() and timeout_at() public factories instead.
+    #
+    # Implementation note: `async with timeout()` is preferred
+    # over `with timeout()`.
+    # While technically the Timeout class implementation
+    # doesn't need to be async at all,
+    # the `async with` statement explicitly points that
+    # the context manager should be used from async function context.
+    #
+    # This design allows to avoid many silly misusages.
+    #
+    # TimeoutError is raised immediately when scheduled
+    # if the deadline is passed.
+    # The purpose is to time out as soon as possible
+    # without waiting for the next await expression.
+
+    __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler")
+
+    def __init__(
+        self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
+    ) -> None:
+        self._loop = loop
+        self._state = _State.INIT
+
+        self._timeout_handler = None  # type: Optional[asyncio.Handle]
+        if deadline is None:
+            self._deadline = None  # type: Optional[float]
+        else:
+            self.update(deadline)
+
+    def __enter__(self) -> "Timeout":
+        warnings.warn(
+            "with timeout() is deprecated, use async with timeout() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._do_enter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self._do_exit(exc_type)
+        return None
+
+    async def __aenter__(self) -> "Timeout":
+        self._do_enter()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self._do_exit(exc_type)
+        return None
+
+    @property
+    def expired(self) -> bool:
+        """Is timeout expired during execution?"""
+        return self._state == _State.TIMEOUT
+
+    @property
+    def deadline(self) -> Optional[float]:
+        return self._deadline
+
+    def reject(self) -> None:
+        """Reject scheduled timeout if any."""
+        # cancel is maybe better name but
+        # task.cancel() raises CancelledError in asyncio world.
+        if self._state not in (_State.INIT, _State.ENTER):
+            raise RuntimeError(f"invalid state {self._state.value}")
+        self._reject()
+
+    def _reject(self) -> None:
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+            self._timeout_handler = None
+
+    def shift(self, delay: float) -> None:
+        """Advance timeout on delay seconds.
+
+        The delay can be negative.
+
+        Raise RuntimeError if shift is called when deadline is not scheduled
+        """
+        deadline = self._deadline
+        if deadline is None:
+            raise RuntimeError("cannot shift timeout if deadline is not scheduled")
+        self.update(deadline + delay)
+
+    def update(self, deadline: float) -> None:
+        """Set deadline to absolute value.
+
+        deadline argument points on the time in the same clock system
+        as loop.time().
+
+        If new deadline is in the past the timeout is raised immediately.
+
+        Please note: it is not POSIX time but a time with
+        undefined starting base, e.g. the time of the system power on.
+        """
+        if self._state == _State.EXIT:
+            raise RuntimeError("cannot reschedule after exit from context manager")
+        if self._state == _State.TIMEOUT:
+            raise RuntimeError("cannot reschedule expired timeout")
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+        self._deadline = deadline
+        if self._state != _State.INIT:
+            self._reschedule()
+
+    def _reschedule(self) -> None:
+        assert self._state == _State.ENTER
+        deadline = self._deadline
+        if deadline is None:
+            return
+
+        now = self._loop.time()
+        if self._timeout_handler is not None:
+            self._timeout_handler.cancel()
+
+        task = asyncio.current_task()
+        if deadline <= now:
+            self._timeout_handler = self._loop.call_soon(self._on_timeout, task)
+        else:
+            self._timeout_handler = self._loop.call_at(deadline, self._on_timeout, task)
+
+    def _do_enter(self) -> None:
+        if self._state != _State.INIT:
+            raise RuntimeError(f"invalid state {self._state.value}")
+        self._state = _State.ENTER
+        self._reschedule()
+
+    def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
+        if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+            self._timeout_handler = None
+            raise asyncio.TimeoutError
+        # timeout has not expired
+        self._state = _State.EXIT
+        self._reject()
+        return None
+
+    def _on_timeout(self, task: "asyncio.Task[None]") -> None:
+        task.cancel()
+        self._state = _State.TIMEOUT
+        # drop the reference early
+        self._timeout_handler = None

--- a/src/websockets/legacy/async_timeout.py
+++ b/src/websockets/legacy/async_timeout.py
@@ -1,5 +1,5 @@
 # From https://github.com/aio-libs/async-timeout/blob/master/async_timeout/__init__.py
-# Licensed under the Apache License, Version 2.0.
+# Licensed under the Apache License (Apache-2.0)
 
 import asyncio
 import enum
@@ -9,11 +9,48 @@ from types import TracebackType
 from typing import Optional, Type
 
 
-if sys.version_info >= (3, 8):
+# From https://github.com/python/typing_extensions/blob/main/src/typing_extensions.py
+# Licensed under the Python Software Foundation License (PSF-2.0)
+
+if sys.version_info >= (3, 11):
     from typing import final
 else:
-    from typing_extensions import final
+    # @final exists in 3.8+, but we backport it for all versions
+    # before 3.11 to keep support for the __final__ attribute.
+    # See https://bugs.python.org/issue46342
+    def final(f):
+        """This decorator can be used to indicate to type checkers that
+        the decorated method cannot be overridden, and decorated class
+        cannot be subclassed. For example:
 
+            class Base:
+                @final
+                def done(self) -> None:
+                    ...
+            class Sub(Base):
+                def done(self) -> None:  # Error reported by type checker
+                    ...
+            @final
+            class Leaf:
+                ...
+            class Other(Leaf):  # Error reported by type checker
+                ...
+
+        There is no runtime checking of these properties. The decorator
+        sets the ``__final__`` attribute to ``True`` on the decorated object
+        to allow runtime introspection.
+        """
+        try:
+            f.__final__ = True
+        except (AttributeError, TypeError):
+            # Skip the attribute silently if it is not writable.
+            # AttributeError happens if the object has __slots__ or a
+            # read-only property, TypeError if it's a builtin class.
+            pass
+        return f
+
+
+# End https://github.com/aio-libs/async-timeout/blob/master/async_timeout/__init__.py
 
 __version__ = "4.0.2"
 
@@ -223,3 +260,6 @@ class Timeout:
         self._state = _State.TIMEOUT
         # drop the reference early
         self._timeout_handler = None
+
+
+# End https://github.com/aio-libs/async-timeout/blob/master/async_timeout/__init__.py

--- a/src/websockets/legacy/client.py
+++ b/src/websockets/legacy/client.py
@@ -44,6 +44,7 @@ from ..headers import (
 from ..http import USER_AGENT
 from ..typing import ExtensionHeader, LoggerLike, Origin, Subprotocol
 from ..uri import WebSocketURI, parse_uri
+from .compatibility import asyncio_timeout
 from .handshake import build_request, check_response
 from .http import read_response
 from .protocol import WebSocketCommonProtocol
@@ -650,7 +651,8 @@ class Connect:
         return self.__await_impl_timeout__().__await__()
 
     async def __await_impl_timeout__(self) -> WebSocketClientProtocol:
-        return await asyncio.wait_for(self.__await_impl__(), self.open_timeout)
+        async with asyncio_timeout(self.open_timeout):
+            return await self.__await_impl__()
 
     async def __await_impl__(self) -> WebSocketClientProtocol:
         for redirects in range(self.MAX_REDIRECTS_ALLOWED):

--- a/src/websockets/legacy/compatibility.py
+++ b/src/websockets/legacy/compatibility.py
@@ -5,6 +5,9 @@ import sys
 from typing import Any, Dict
 
 
+__all__ = ["asyncio_timeout", "loop_if_py_lt_38"]
+
+
 if sys.version_info[:2] >= (3, 8):
 
     def loop_if_py_lt_38(loop: asyncio.AbstractEventLoop) -> Dict[str, Any]:
@@ -22,3 +25,9 @@ else:
 
         """
         return {"loop": loop}
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout as asyncio_timeout  # noqa: F401
+else:
+    from .async_timeout import timeout as asyncio_timeout  # noqa: F401

--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -1361,7 +1361,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         # Abort the TCP connection. Buffers are discarded.
         if self.debug:
             self.logger.debug("x aborting TCP connection")
-        self.transport.abort()
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.transport.abort()  # pragma: no cover
 
         # connection_lost() is called quickly after aborting.
         await self.wait_for_connection_lost()

--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -107,7 +107,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
       context manager;
     * on the server side, when the connection handler terminates.
 
-    To apply a timeout to any other API, wrap it in :func:`~asyncio.wait_for`.
+    To apply a timeout to any other API, wrap it in :func:`~asyncio.timeout` or
+    :func:`~asyncio.wait_for`.
 
     The ``max_size`` parameter enforces the maximum size for incoming messages
     in bytes. The default value is 1 MiB. If a larger message is received,
@@ -513,7 +514,7 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         message. The next invocation of :meth:`recv` will return it.
 
         This makes it possible to enforce a timeout by wrapping :meth:`recv` in
-        :func:`~asyncio.wait_for`.
+        :func:`~asyncio.timeout` or :func:`~asyncio.wait_for`.
 
         Returns:
             Data: A string (:class:`str`) for a Text_ frame. A bytestring

--- a/src/websockets/legacy/protocol.py
+++ b/src/websockets/legacy/protocol.py
@@ -53,7 +53,7 @@ from ..frames import (
 )
 from ..protocol import State
 from ..typing import Data, LoggerLike, Subprotocol
-from .compatibility import loop_if_py_lt_38
+from .compatibility import asyncio_timeout, loop_if_py_lt_38
 from .framing import Frame
 
 
@@ -761,19 +761,16 @@ class WebSocketCommonProtocol(asyncio.Protocol):
 
         """
         try:
-            await asyncio.wait_for(
-                self.write_close_frame(Close(code, reason)),
-                self.close_timeout,
-                **loop_if_py_lt_38(self.loop),
-            )
+            async with asyncio_timeout(self.close_timeout):
+                await self.write_close_frame(Close(code, reason))
         except asyncio.TimeoutError:
             # If the close frame cannot be sent because the send buffers
             # are full, the closing handshake won't complete anyway.
             # Fail the connection to shut down faster.
             self.fail_connection()
 
-        # If no close frame is received within the timeout, wait_for() cancels
-        # the data transfer task and raises TimeoutError.
+        # If no close frame is received within the timeout, asyncio_timeout()
+        # cancels the data transfer task and raises TimeoutError.
 
         # If close() is called multiple times concurrently and one of these
         # calls hits the timeout, the data transfer task will be canceled.
@@ -782,11 +779,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         try:
             # If close() is canceled during the wait, self.transfer_data_task
             # is canceled before the timeout elapses.
-            await asyncio.wait_for(
-                self.transfer_data_task,
-                self.close_timeout,
-                **loop_if_py_lt_38(self.loop),
-            )
+            async with asyncio_timeout(self.close_timeout):
+                await self.transfer_data_task
         except (asyncio.TimeoutError, asyncio.CancelledError):
             pass
 
@@ -1268,11 +1262,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
 
                 if self.ping_timeout is not None:
                     try:
-                        await asyncio.wait_for(
-                            pong_waiter,
-                            self.ping_timeout,
-                            **loop_if_py_lt_38(self.loop),
-                        )
+                        async with asyncio_timeout(self.ping_timeout):
+                            await pong_waiter
                         self.logger.debug("% received keepalive pong")
                     except asyncio.TimeoutError:
                         if self.debug:
@@ -1384,11 +1375,8 @@ class WebSocketCommonProtocol(asyncio.Protocol):
         """
         if not self.connection_lost_waiter.done():
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(self.connection_lost_waiter),
-                    self.close_timeout,
-                    **loop_if_py_lt_38(self.loop),
-                )
+                async with asyncio_timeout(self.close_timeout):
+                    await asyncio.shield(self.connection_lost_waiter)
             except asyncio.TimeoutError:
                 pass
         # Re-check self.connection_lost_waiter.done() synchronously because

--- a/tests/legacy/test_client_server.py
+++ b/tests/legacy/test_client_server.py
@@ -29,6 +29,7 @@ from websockets.extensions.permessage_deflate import (
 )
 from websockets.http import USER_AGENT
 from websockets.legacy.client import *
+from websockets.legacy.compatibility import asyncio_timeout
 from websockets.legacy.handshake import build_response
 from websockets.legacy.http import read_response
 from websockets.legacy.server import *
@@ -1129,7 +1130,8 @@ class CommonClientServerTests:
 
         async def cancelled_client():
             start_client = connect(get_server_uri(self.server), sock=sock)
-            await asyncio.wait_for(start_client, 5 * MS)
+            async with asyncio_timeout(5 * MS):
+                await start_client
 
         with self.assertRaises(asyncio.TimeoutError):
             self.loop.run_until_complete(cancelled_client())

--- a/tests/legacy/test_protocol.py
+++ b/tests/legacy/test_protocol.py
@@ -1579,7 +1579,8 @@ class ServerTests(CommonTests, AsyncioTestCase):
             self.receive_frame(self.close_frame)
             self.run_loop_once()
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1000, "close")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1000, "close")  # pragma: no cover
 
     def test_local_close_connection_lost_timeout_after_close(self):
         self.protocol.close_timeout = 10 * MS
@@ -1596,7 +1597,8 @@ class ServerTests(CommonTests, AsyncioTestCase):
             self.receive_frame(self.close_frame)
             self.run_loop_once()
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1000, "close")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1000, "close")  # pragma: no cover
 
 
 class ClientTests(CommonTests, AsyncioTestCase):
@@ -1614,7 +1616,8 @@ class ClientTests(CommonTests, AsyncioTestCase):
         # Check the timing within -1/+9ms for robustness.
         with self.assertCompletesWithin(19 * MS, 29 * MS):
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1006, "")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1006, "")  # pragma: no cover
 
     def test_local_close_receive_close_frame_timeout(self):
         self.protocol.close_timeout = 10 * MS
@@ -1624,7 +1627,8 @@ class ClientTests(CommonTests, AsyncioTestCase):
         # Check the timing within -1/+9ms for robustness.
         with self.assertCompletesWithin(19 * MS, 29 * MS):
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1006, "")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1006, "")  # pragma: no cover
 
     def test_local_close_connection_lost_timeout_after_write_eof(self):
         self.protocol.close_timeout = 10 * MS
@@ -1639,7 +1643,8 @@ class ClientTests(CommonTests, AsyncioTestCase):
             self.receive_frame(self.close_frame)
             self.run_loop_once()
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1000, "close")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1000, "close")  # pragma: no cover
 
     def test_local_close_connection_lost_timeout_after_close(self):
         self.protocol.close_timeout = 10 * MS
@@ -1659,4 +1664,5 @@ class ClientTests(CommonTests, AsyncioTestCase):
             self.receive_frame(self.close_frame)
             self.run_loop_once()
             self.loop.run_until_complete(self.protocol.close(reason="close"))
-        self.assertConnectionClosed(1000, "close")
+        # Due to a bug in coverage, this is erroneously reported as not covered.
+        self.assertConnectionClosed(1000, "close")  # pragma: no cover


### PR DESCRIPTION
`asyncio.wait_for` creates a task whereas `asyncio.timeout` avoids doing this which decreases latency.

Fallback to using `async_timeout` when the python version is too old (<3.11)

`asyncio.timeout` will become the underlying implementation for `async.wait_for` in cpython 3.12
https://github.com/python/cpython/pull/98518